### PR TITLE
[FEAT] CLI overhaul, stdin support, some refactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ similar = "2.6.0"
 
 [dependencies]
 serde = { version = "1.0.210", features = ["derive"] }
-clap = "4.5.16"
+clap = { version = "4.5.16", features = ["cargo"] }
 toml = "0.8.19"
 typed-arena = "2.0.2"
 tree-sitter = "0.24.3"

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ Visit the [release page](https://github.com/xixiaofinland/afmt/releases/latest) 
 
 Create a `file.cls` file with valid Apex code.
 
-### Dry Run:
+### Format source code from stdin:
 
-Run `afmt ./file.cls` to preview the formatting result.
+Run `afmt < ./file.cls` to format the code from stdin and output the formatted code.
+This is useful for piping the output to another command or tool.
 
 ```bash
-> afmt ./file.cls
-Result 0: Ok
+> afmt < ./file.cls
 global class PluginDescribeResult {
     {
         [SELECT FIELDS(STANDARD) FROM Organization LIMIT 1];
@@ -112,15 +112,31 @@ global class PluginDescribeResult {
 }
 ```
 
+### Check files:
+
+Run `afmt --check ./file.cls` to preview the formatting result.
+
+```bash
+> afmt --check ./file.cls
+file ./file.cls needs formatting
+
+Afmt completed successfully. Processed 1 files
+
+Execution time: 15.053216ms
+```
+
 ### Format and Write:
 
-Run `afmt -w ./file.cls` to format the file and overwrite it with the
+Run `afmt --write ./file.cls` to format the file and overwrite it with the
    formatted code.
 
 ```bash
-> afmt -w ./file.cls
-Formatted content written back to: ./file.cls
-Afmt completed successfully.
+> afmt --write ./file.cls
+file ./file.cls has been formatted
+
+Afmt completed successfully. Processed 1 files
+
+Execution time: 10.080986ms
 ```
 <br>
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,45 +1,54 @@
-use clap::{Arg as ClapArg, Command};
+use crate::formatter::Mode;
+use clap::{Arg as ClapArg, ArgGroup, Command, Id, ValueHint};
+use std::{io::IsTerminal, path::PathBuf};
 
 #[derive(Debug)]
 pub struct Args {
-    pub path: String,
+    pub paths: Vec<PathBuf>,
     pub config: Option<String>,
-    pub write: bool,
+    pub mode: Mode,
 }
 
 pub fn get_args() -> Args {
     let version = env!("CARGO_PKG_VERSION"); // read from Cargo.toml in compiling time
 
-    let matches = Command::new("afmt")
+    let mut command = Command::new("afmt")
         .version(version)
         .about(format!("Apex format tool (afmt): {}", version))
-        .arg_required_else_help(true)
-        .arg(
-            ClapArg::new("file")
-                .value_name("FILE")
-                .help("The relative path to the file to parse")
-                .required(true)
-                .index(1),
-        )
         .arg(
             ClapArg::new("config")
-                .short('c')
                 .long("config")
                 .value_name("CONFIG")
-                .help("Path to the .afmt.toml configuration file"),
+                .help("Path to the .afmt.toml configuration file")
+                .value_hint(ValueHint::FilePath),
+        )
+        .arg(
+            ClapArg::new("check")
+                .short('c')
+                .long("check")
+                .num_args(1..)
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("Check files for formatting issues")
+                .value_hint(ValueHint::FilePath),
         )
         .arg(
             ClapArg::new("write")
                 .short('w')
                 .long("write")
-                .help("Write the formatted result back to the file")
-                .action(clap::ArgAction::SetTrue),
+                .num_args(1..)
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("Write the formatted result back to the files")
+                .value_hint(ValueHint::FilePath),
         )
+        .group(ArgGroup::new("check_or_write").arg("check").arg("write"))
         .after_help(
             "EXAMPLES:\n\
              \n\
-             # Dry run: print the result without overwriting the file\n\
-             afmt ./file.cls\n\
+             # Read source code from stdin and output to stdout without writing any files\n\
+             afmt < ./file.cls\n\
+             \n\
+             # Check if any of the specified files would be modified\n\
+             afmt --check ./file.cls\n\
              \n\
              # Format and write changes back to the file\n\
              afmt --write src/file.cls\n\
@@ -47,15 +56,40 @@ pub fn get_args() -> Args {
              # Use a specific config file\n\
              afmt --config .afmt.toml ./file.cls\n\
             ",
-        )
-        .get_matches();
+        );
+
+    let matches = command.get_matches_mut();
+
+    let mode = match matches.get_one::<Id>("check_or_write").map(|i| i.as_str()) {
+        Some("check") => Mode::Check,
+        Some("write") => Mode::Write,
+        _ => Mode::Std,
+    };
+
+    if Mode::Std == mode && std::io::stdin().is_terminal() {
+        command.print_help().unwrap();
+        std::process::exit(2);
+    }
+
+    let paths = match mode {
+        Mode::Check => matches
+            .get_many::<PathBuf>("check")
+            .into_iter()
+            .flatten()
+            .cloned()
+            .collect(),
+        Mode::Write => matches
+            .get_many::<PathBuf>("write")
+            .into_iter()
+            .flatten()
+            .cloned()
+            .collect(),
+        Mode::Std => vec![],
+    };
 
     Args {
-        path: matches
-            .get_one::<String>("file")
-            .expect("File path is required")
-            .to_string(),
         config: matches.get_one::<String>("config").map(|s| s.to_string()),
-        write: matches.get_flag("write"),
+        mode,
+        paths,
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
 use crate::formatter::Mode;
-use clap::{Arg as ClapArg, ArgGroup, Command, Id, ValueHint};
+use clap::{crate_version, value_parser, Arg as ClapArg, ArgGroup, Command, Id, ValueHint};
 use std::{io::IsTerminal, path::PathBuf};
 
 #[derive(Debug)]
@@ -10,7 +10,7 @@ pub struct Args {
 }
 
 pub fn get_args() -> Args {
-    let version = env!("CARGO_PKG_VERSION"); // read from Cargo.toml in compiling time
+    let version = crate_version!(); // read from Cargo.toml in compiling time
 
     let mut command = Command::new("afmt")
         .version(version)
@@ -27,7 +27,7 @@ pub fn get_args() -> Args {
                 .short('c')
                 .long("check")
                 .num_args(1..)
-                .value_parser(clap::value_parser!(PathBuf))
+                .value_parser(value_parser!(PathBuf))
                 .help("Check files for formatting issues")
                 .value_hint(ValueHint::FilePath),
         )
@@ -36,7 +36,7 @@ pub fn get_args() -> Args {
                 .short('w')
                 .long("write")
                 .num_args(1..)
-                .value_parser(clap::value_parser!(PathBuf))
+                .value_parser(value_parser!(PathBuf))
                 .help("Write the formatted result back to the files")
                 .value_hint(ValueHint::FilePath),
         )
@@ -48,13 +48,13 @@ pub fn get_args() -> Args {
              afmt < ./file.cls\n\
              \n\
              # Check if any of the specified files would be modified\n\
-             afmt --check ./file.cls\n\
+             afmt --check ./**/*.cls\n\
              \n\
-             # Format and write changes back to the file\n\
+             # Format and write changes back to the files\n\
              afmt --write src/file.cls\n\
              \n\
              # Use a specific config file\n\
-             afmt --config .afmt.toml ./file.cls\n\
+             afmt --config .afmt.toml --write ./file.cls\n\
             ",
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ mod enum_def;
 pub mod formatter;
 pub mod message_helper;
 mod utility;
-use formatter::Formatter;
+use formatter::{FormatResult, Formatter};
 
-pub fn format(f: Formatter) -> Vec<Result<String, String>> {
+pub fn format(f: Formatter) -> Vec<Result<FormatResult, String>> {
     f.format()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use sf_afmt::args::{get_args, Args};
 use sf_afmt::format;
 use sf_afmt::formatter::{Formatter, Mode};
+use sf_afmt::message_helper::yellow;
 use std::io::{self, IsTerminal, Write};
 use std::process;
 use std::time::Instant;
@@ -8,12 +9,14 @@ use std::time::Instant;
 fn main() {
     let start = Instant::now();
 
-    let result = run(get_args());
-
-    match result {
+    let args = get_args();
+    match run(&args) {
         Ok(_) => {
             if std::io::stdout().is_terminal() {
-                println!("Afmt completed successfully.");
+                println!(
+                    "\nAfmt completed successfully. Processed {} files",
+                    args.paths.len().max(1)
+                );
                 let duration = start.elapsed();
                 println!("\nExecution time: {:?}", duration);
             }
@@ -26,32 +29,44 @@ fn main() {
     }
 }
 
-fn run(args: Args) -> Result<(), String> {
-    let formatter =
-        Formatter::create_from_config(args.config.as_deref(), args.mode.to_owned(), args.paths)?;
+fn run(args: &Args) -> Result<(), String> {
+    let formatter = Formatter::create_from_config(
+        args.config.as_deref(),
+        args.mode.to_owned(),
+        args.paths.to_owned(),
+    )?;
     let results = format(formatter);
     let mut stdout = io::stdout();
     let is_terminal = stdout.is_terminal();
 
-    for (index, result) in results.iter().enumerate() {
-        match (result, args.mode.to_owned()) {
-            (Ok(value), Mode::Std) => {
-                stdout.write_all(value.as_bytes()).unwrap();
+    for (index, format_result) in results.iter().enumerate() {
+        let format_result = format_result
+            .as_ref()
+            .map_err(|e| format!("Error processing file {}: {}", index, e))?;
+        let file_path = format_result.file_path.to_str().unwrap_or_default();
+
+        match (args.mode.to_owned(), format_result.is_changed, is_terminal) {
+            (Mode::Std, _, _) => {
+                stdout
+                    .write_all(format_result.formatted_code.as_bytes())
+                    .map_err(|e| format!("Couldn't write formatted code to stdout: {}", e))?;
             }
-            (Ok(value), Mode::Check) => {
-                let message = if is_terminal {
-                    format!("Result {}: Ok", index)
-                } else {
-                    index.to_string()
-                };
-                println!("{}", message);
+            (_, true, false) => {
+                println!("{}", file_path);
             }
-            (Ok(value), Mode::Write) => {
-                println!("Result {}: Ok", index);
+            (Mode::Write, true, true) => {
+                println!("file {} has been formatted", file_path);
             }
-            (Err(e), _) => {
-                return Err(format!("Error processing result {}: {}", index, e));
+            (Mode::Check, true, true) => {
+                println!(
+                    "{}",
+                    yellow(&format!("file {} needs formatting", file_path))
+                );
             }
+            (_, false, true) => {
+                println!("file {} is already formatted", file_path);
+            }
+            _ => {}
         }
     }
 

--- a/tests/battle_test/battle_testing.sh
+++ b/tests/battle_test/battle_testing.sh
@@ -69,13 +69,13 @@ while IFS= read -r REPO_URL || [ -n "$REPO_URL" ]; do
 
     echo "Cloning $REPO_URL into $REPO_PATH"
 
-    if [ -d "$REPO_PATH" ]; then
-        echo "Directory already exists, removing it..."
-        rm -rf "$REPO_PATH"
-    fi
-
     # Clone with retries and proper error handling
     for i in {1..3}; do
+        if [ -d "$REPO_PATH" ]; then
+            echo "Directory already exists, no need to clone again"
+            break
+        fi
+
         if git clone --depth 1 --single-branch "$REPO_URL" "$REPO_PATH" 2>> "$LOG_FILE"; then
             break
         else
@@ -99,7 +99,7 @@ format_files() {
 
     # echo "Processing file: $FILE_PATH"
 
-    OUTPUT=$($FORMATTER_BINARY "$FILE_PATH" 2>&1)
+    OUTPUT=$($FORMATTER_BINARY < "$FILE_PATH" 2>&1)
     EXIT_CODE=$?
 
     if [ $EXIT_CODE -ne 0 ]; then

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -120,7 +120,7 @@ mod tests {
             )
         });
 
-        compare("Static:", output, expected, source)
+        compare("Static:", output.formatted_code, expected, source)
     }
 
     fn run_prettier_test_files(source: &Path, config_name: &str) -> bool {
@@ -146,7 +146,7 @@ mod tests {
         let prettier_output = std::fs::read_to_string(&prettier_file)
             .expect("Failed to read the prettier formatted file.");
 
-        compare("Prettier:", output, prettier_output, source)
+        compare("Prettier:", output.formatted_code, prettier_output, source)
     }
 
     fn normalize(content: &str) -> String {
@@ -188,14 +188,12 @@ mod tests {
         }
     }
 
-    fn format_with_afmt(source: &Path, config_path: Option<&str>) -> String {
-        let file_path = source
-            .to_str()
-            .expect("PathBuf to String failed.")
-            .to_string();
+    fn format_with_afmt(source: &Path, config_path: Option<&str>) -> FormatResult {
+        let file_path = source.to_path_buf();
 
-        let formatter = Formatter::create_from_config(config_path, vec![file_path.clone()])
-            .expect("Create formatter failed.");
+        let formatter =
+            Formatter::create_from_config(config_path, Mode::Write, vec![file_path.clone()])
+                .expect("Create formatter failed.");
 
         let vec = formatter.format();
         vec.into_iter()


### PR DESCRIPTION
## description
originally i just wanted to add stdin support to integrate afmt into neovim through efm-langserver, but then it kind of escalated quickly. if wanted i could also only take parts of the changes into seperate PRs.

in order to not spend more time going in a possibly unwanted direction with this, i am putting this up for early feedback. 

The new CLI is very similar to prettier's and opens some interesting possibilities, that i want to add to the README as well if you want this change in the first place, like:
- using `--check` and a bash 3 liner to annotate unformatted code in a github action
- configuring afmt in efm-langserver to use in neovim or other editors

Looking forward to your feedback, thanks for contributing this tool and taking it open-source! 