### PR TITLE
docs(config): align annotation casing configuration guide

### DIFF
--- a/.afmt.toml
+++ b/.afmt.toml
@@ -5,3 +5,8 @@ max_width = 80
 
 # Indentation size in spaces
 indent_size = 4
+
+# Optional replacement file-selection arrays. Uncomment to customize them.
+# [files]
+# include = ["**/*.cls", "**/*.trigger", "**/*.apex", "**/*.apexc"]
+# exclude = ["**/.git/**", "**/.sfdx/**", "**/node_modules/**"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent guidance
+
+`afmt` is a Rust CLI and library for formatting Salesforce Apex. Keep this file
+as a navigation aid for coding agents; put durable behavior details in the
+focused project documentation below.
+
+- Comment placement and formatter idempotency:
+  [docs/comment-placement-and-idempotency.md](docs/comment-placement-and-idempotency.md)
+- Basic installation and usage examples: [README.md](README.md)
+
+When changing formatting behavior, update the focused guide and its relevant
+fixtures/tests together. Keep `CLAUDE.md` unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent guidance
+
+`afmt` is a Rust CLI and library for formatting Salesforce Apex. Keep this
+file as a navigation aid for coding agents; put durable behavior details in
+the focused project documentation below.
+
+- Formatter configuration and style behavior:
+  [docs/configuration.md](docs/configuration.md)
+- Basic installation and usage examples: [README.md](README.md)
+
+When changing formatter behavior, update the focused guide and its relevant
+tests together. Keep `CLAUDE.md` unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent guidance
+
+`afmt` is a Rust CLI and library for formatting Salesforce Apex. Keep this
+file as a navigation aid for coding agents; put durable behavior details in
+the focused project documentation below.
+
+- User-facing bulk formatting, configuration, discovery, and CLI semantics:
+  [docs/project-wide-formatting.md](docs/project-wide-formatting.md)
+- Test, battle-corpus, and local benchmark workflow:
+  [docs/validation-and-benchmarks.md](docs/validation-and-benchmarks.md)
+- Basic installation and usage examples: [README.md](README.md)
+
+When changing project-wide formatting behavior, update the focused guide and
+its relevant tests together. Keep `CLAUDE.md` unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,62 +28,73 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.10"
+name = "bstr"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -93,33 +104,82 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -127,45 +187,65 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
-name = "once_cell"
-version = "1.20.2"
+name = "once_cell_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
+name = "rayon"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -175,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -186,24 +266,43 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -212,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -224,25 +323,28 @@ name = "sf-afmt"
 version = "0.12.2"
 dependencies = [
  "clap",
+ "globset",
+ "rayon",
  "serde",
  "similar",
  "toml",
  "tree-sitter",
  "tree-sitter-sfapex",
  "typed-arena",
+ "walkdir",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "streaming-iterator"
@@ -258,9 +360,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -269,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -281,25 +383,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree-sitter"
@@ -316,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c199356c799a8945965bb5f2c55b2ad9d9aa7c4b4f6e587fe9dea0bc715e5f9c"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-sfapex"
@@ -338,9 +447,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -349,83 +458,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ toml = "0.8.19"
 typed-arena = "2.0.2"
 tree-sitter = "0.24.3"
 tree-sitter-sfapex = "2.4.0"
+rayon = "1.10.0"
+globset = { version = "0.4.15", default-features = false }
+walkdir = "2.5.0"
 
 [profile.dev]
 opt-level = 1

--- a/README.md
+++ b/README.md
@@ -163,11 +163,18 @@ indent_size = 4
 # brace_style = "k_and_r"            # or "allman"
 # wrap_single_statements = false      # add braces to bare clause bodies
 # indent_style = "space"              # or "tab"
+# normalize_annotation_casing = false  # canonicalize known annotation names
 ```
 
 When `indent_style = "tab"`, `indent_size` controls the number of columns per
 indent level. Line wrapping measures each emitted tab as one logical column;
 visual tab stops may therefore differ from `max_width` calculations.
+
+When `normalize_annotation_casing = true`, known Apex annotation names are
+written with Salesforce's canonical casing, such as `@IsTest`, `@TestSetup`,
+and `@AuraEnabled`. Unknown annotation names remain verbatim. This option only
+normalizes the annotation name; annotation argument keys and values are left
+unchanged.
 
 Allman formatting places property and accessor body braces on their own lines.
 Compact auto-properties without accessor bodies keep their `{ get; set; }`

--- a/README.md
+++ b/README.md
@@ -118,13 +118,35 @@ Visit the [release page](https://github.com/xixiaofinland/afmt/releases/latest) 
 
 Create a `file.cls` file with valid Apex code.
 
+### Common commands
+
+```bash
+# Format one file to stdout
+afmt AccountService.cls
+
+# Recursively format a directory in place
+afmt --write force-app
+
+# Check multiple files and directories without writing
+afmt --check force-app packages/shared.cls
+
+# Use an explicitly supplied config and print per-file timing
+afmt --config .afmt.toml --time --write .
+```
+
+Directory inputs recursively select `.cls`, `.trigger`, `.apex`, and `.apexc`
+files in deterministic path order. Overlapping paths are processed once.
+Explicit files bypass the include patterns but still honor exclusions, and an
+exclude match always wins. The default exclusions are `.git`, `.sfdx`, and
+`node_modules`; a supplied `[files].exclude` array replaces those defaults, so
+repeat any defaults you still want.
+
 ### Dry Run:
 
 Run `afmt ./file.cls` to preview the formatting result.
 
 ```bash
 > afmt ./file.cls
-Result 0: Ok
 global class PluginDescribeResult {
     {
         [SELECT FIELDS(STANDARD) FROM Organization LIMIT 1];
@@ -135,14 +157,25 @@ global class PluginDescribeResult {
 ### Format and Write:
 
 Run `afmt -w ./file.cls` to format the file and overwrite it with the
-   formatted code.
+formatted code. Unchanged files are not rewritten.
 
 ```bash
 > afmt -w ./file.cls
-Formatted content written back to: ./file.cls
-Afmt completed successfully.
 ```
 <br>
+
+For multiple files, `--write` is best effort: a read, parse, format, or write
+failure is reported with its path, while other valid files continue. A final
+stderr summary reports selected, changed, written, unchanged, failed, and
+elapsed counts. `--check` never writes, lists every file that would change,
+and exits nonzero for any changed file, processing failure, or empty selection.
+`--time` adds one stderr timing line per selected file and a total; it never
+changes formatted stdout.
+
+Single-file dry runs print only formatted Apex source. Multi-file dry runs
+print each source block with a deterministic `==> path <==` delimiter. Exit
+code `0` means formatting or checking succeeded; exit code `1` means an
+application error, changed file in check mode, or partial write failure.
 
 ## 🔧 Configuration:
 
@@ -150,7 +183,9 @@ Afmt completed successfully.
 
 Example: `afmt -c .afmt.toml`
 
-In `.afmt.toml` config file, two options are supported
+In an explicitly supplied `.afmt.toml` config file, formatter settings and
+optional file-selection settings are supported. A config file is not loaded
+implicitly.
 
 ```toml
 # Maximum line width
@@ -158,7 +193,20 @@ max_width = 80
 
 # Indentation size in spaces
 indent_size = 4
+
+# Optional replacement selection arrays. Uncomment to customize them.
+# [files]
+# include = ["**/*.cls", "**/*.trigger", "**/*.apex", "**/*.apexc"]
+# exclude = ["**/.git/**", "**/.sfdx/**", "**/node_modules/**"]
 ```
+
+Each supplied include or exclude array replaces its corresponding default.
+Patterns use portable `/` separators and are matched relative to the config
+directory when possible.
+
+For the complete project-wide behavior and contributor validation workflow,
+see [the project-wide formatting guide](docs/project-wide-formatting.md) and
+[the validation and benchmark guide](docs/validation-and-benchmarks.md).
 
 <br>
 
@@ -182,6 +230,13 @@ PRs.
 
 Scenarios (e.g., new features, bug fixes) must be covered by tests, and `cargo test` passes.
 Refer to `*.in` (before format) and `*.cls` (after format) files in the [test folder](./tests/static).
+
+The active static, prettier80, and comments fixtures each have a separate
+two-pass idempotency test. For local bulk-performance measurements, run
+`tests/battle_test/benchmark_bulk.sh /path/to/a/local/corpus`; it builds once,
+keeps the corpus unchanged, and compares sequential process startup with one
+bulk invocation. The battle test uses the bulk command first and retains a
+per-file diagnostic fallback for tolerated managed-package templates.
 
 Also, our CI [pipeline](.github/workflows/pr-ci-merge-main.yml) ensures high-quality contributions.
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,13 @@ indent_size = 4
 # brace_style = "k_and_r"            # or "allman"
 # wrap_single_statements = false      # add braces to bare clause bodies
 # indent_style = "space"              # or "tab"
+# javadoc_star_column = "offset"      # or "flush"
 ```
+
+`javadoc_star_column = "flush"` aligns JavaDoc continuation stars with the
+comment's indentation column (`* content`); the default `"offset"` preserves
+afmt's existing style (` * content`). In either mode, afmt normalizes the
+separator after the star to one space.
 
 When `indent_style = "tab"`, `indent_size` controls the number of columns per
 indent level. Line wrapping measures each emitted tab as one logical column;
@@ -172,6 +178,9 @@ visual tab stops may therefore differ from `max_width` calculations.
 Allman formatting places property and accessor body braces on their own lines.
 Compact auto-properties without accessor bodies keep their `{ get; set; }`
 contents on one line.
+
+See the [formatter configuration guide](docs/configuration.md) for the
+complete option behavior and defaults.
 <br>
 
 ## ❓ FAQ

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Afmt completed successfully.
 
 Example: `afmt -c .afmt.toml`
 
-In `.afmt.toml` config file, two options are supported
+In `.afmt.toml` config file, the following options are supported
 
 ```toml
 # Maximum line width
@@ -158,8 +158,20 @@ max_width = 80
 
 # Indentation size in spaces
 indent_size = 4
+
+# Optional style controls (defaults preserve afmt's existing output)
+# brace_style = "k_and_r"            # or "allman"
+# wrap_single_statements = false      # add braces to bare clause bodies
+# indent_style = "space"              # or "tab"
 ```
 
+When `indent_style = "tab"`, `indent_size` controls the number of columns per
+indent level. Line wrapping measures each emitted tab as one logical column;
+visual tab stops may therefore differ from `max_width` calculations.
+
+Allman formatting places property and accessor body braces on their own lines.
+Compact auto-properties without accessor bodies keep their `{ get; set; }`
+contents on one line.
 <br>
 
 ## ❓ FAQ

--- a/docs/comment-placement-and-idempotency.md
+++ b/docs/comment-placement-and-idempotency.md
@@ -1,0 +1,70 @@
+# Comment placement and formatter idempotency
+
+`afmt` treats stable output as a formatter contract: formatting already
+formatted output must produce the same output. Comment attachment is part of
+that contract, including when a comment sits between a leading token and the
+following Apex node.
+
+## Supported placements
+
+- A line comment before a chained method name is emitted on its own line before
+  the navigation operator and method name:
+
+  ```apex
+  new Builder()
+    // explain the chained call
+    .build();
+  ```
+
+- A block comment authored on the same line as an unbraced `else` remains
+  trailing on the `else` keyword:
+
+  ```apex
+  else /* explain the fallback */
+    fallback();
+  ```
+
+- Mixed block and line comments before a chained method preserve their authored
+  order and line boundaries.
+
+These placements are attachment behavior, not alternate brace or indentation
+styles.
+
+## Implementation boundaries
+
+- `src/utility.rs::collect_comments` attaches same-row comments after an
+  `else` token and marks that attachment for inline rendering.
+- `src/data_model.rs::MethodInvocationKind::Complex` hoists line pre-comments
+  ahead of a chained navigation operator and suppresses their duplicate
+  emission from the method name.
+- `src/data_model.rs::ValueNode::build_without_pre_comments` preserves the
+  method name's remaining post-comments and punctuation when the pre-comments
+  are hoisted.
+
+## Regression coverage
+
+The static fixtures under `tests/static/` cover the method-chain and unbraced
+`else` placements, including both mixed-comment orders. The focused
+`idempotency_static` test formats each fixture twice with the same
+`tests/configs/.afmt_static.toml` configuration.
+
+Run the focused checks while iterating:
+
+```bash
+cargo test --locked --test test idempotency_static
+cargo test --locked --test test statics
+cargo test --locked --test test comments
+```
+
+Run the complete locked Rust suite before handoff:
+
+```bash
+cargo test --locked --all-features
+```
+
+The larger battle test uses an external Apex corpus and requires network access;
+run it separately when that corpus is available:
+
+```bash
+./tests/battle_test/battle_testing.sh --idempotent
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,36 @@
+# Formatter configuration
+
+`afmt` reads configuration only when a file is explicitly supplied with
+`--config` or `-c`. It does not discover `.afmt.toml` implicitly. Omitted
+options retain the formatter defaults.
+
+```toml
+max_width = 80
+indent_size = 2
+
+# Optional style controls
+brace_style = "k_and_r"            # or "allman"
+wrap_single_statements = false      # or true
+indent_style = "space"              # or "tab"
+javadoc_star_column = "offset"      # or "flush"
+```
+
+`brace_style = "allman"` puts opening braces on their own lines. The default
+`"k_and_r"` keeps them on the construct's header line.
+
+`wrap_single_statements = true` adds braces around otherwise bare `if`,
+`else`, and loop bodies. The default is `false`.
+
+`indent_style` selects spaces or tabs for emitted indentation. `indent_size`
+controls the logical indentation width; with tabs, it is the number of columns
+represented by each indentation level.
+
+`javadoc_star_column` controls only the leading star on continuation lines in
+Javadoc (`/** ... */`) comments:
+
+- `"offset"` (default) emits ` * content`, preserving existing output.
+- `"flush"` emits `* content`, aligning the star with the comment indentation.
+
+In both modes, afmt normalizes the separator after the star to one space.
+Blank Javadoc lines and the closing line follow the same star-column choice.
+Non-Javadoc block comments and line comments are unaffected by this option.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ brace_style = "k_and_r"            # or "allman"
 wrap_single_statements = false      # or true
 indent_style = "space"              # or "tab"
 javadoc_star_column = "offset"      # or "flush"
+normalize_annotation_casing = false
 ```
 
 `brace_style = "allman"` puts opening braces on their own lines. The default
@@ -34,3 +35,10 @@ Javadoc (`/** ... */`) comments:
 In both modes, afmt normalizes the separator after the star to one space.
 Blank Javadoc lines and the closing line follow the same star-column choice.
 Non-Javadoc block comments and line comments are unaffected by this option.
+
+`normalize_annotation_casing` defaults to `false`, preserving authored
+annotation casing. When enabled, known Salesforce Apex annotation names use
+canonical casing: `@isTest` becomes `@IsTest`, `@testsetup` becomes
+`@TestSetup`, and `@auraenabled` becomes `@AuraEnabled`. Unknown or custom
+annotation names remain verbatim. Only the annotation name is normalized;
+argument keys, values, strings, and surrounding comments are unchanged.

--- a/docs/project-wide-formatting.md
+++ b/docs/project-wide-formatting.md
@@ -1,0 +1,78 @@
+# Project-wide formatting
+
+This guide documents the as-built behavior of the bulk `afmt` CLI. The
+formatter still accepts a single file, but positional inputs are now one or
+more files or directories.
+
+## Inputs and discovery
+
+- A directory is traversed recursively without following directory symlinks.
+- Eligible files use the `.cls`, `.trigger`, `.apex`, or `.apexc` extensions.
+- Explicit file inputs bypass the include globs, but exclusions still apply.
+- Overlapping inputs are de-duplicated.
+- Results are processed in deterministic normalized path order.
+- All paths remain OS-native for file operations; glob matching uses portable
+  `/` separators.
+- A missing, unsupported, or otherwise invalid input is reported before
+  formatting. An input set with no eligible files is an error.
+
+The default exclusions are `.git`, `.sfdx`, and `node_modules`. Directory
+symlinks are not followed during discovery. `afmt` does not read `.gitignore`.
+
+## Configuration
+
+Configuration is opt-in: pass `--config` (or `-c`) to load a TOML file. No
+configuration file is discovered implicitly. Existing flat formatter keys
+remain valid:
+
+```toml
+max_width = 80
+indent_size = 4
+
+[files]
+include = ["**/*.cls", "**/*.trigger", "**/*.apex", "**/*.apexc"]
+exclude = ["**/.git/**", "**/.sfdx/**", "**/node_modules/**"]
+```
+
+The `[files].include` and `[files].exclude` arrays replace their respective
+defaults when supplied; they do not merge with them. Exclusions always win
+over inclusions. Invalid glob syntax is a configuration error and prevents
+formatting.
+
+Patterns are matched against paths relative to the config file's parent when
+`--config` is supplied, or relative to the process working directory when no
+config is supplied. Patterns should use `/` separators so the same config is
+portable across Windows, macOS, and Linux.
+
+## Output and exit behavior
+
+```text
+afmt [OPTIONS] <PATH>...
+```
+
+- Without `--write` or `--check`, formatted source is written to stdout.
+- A single-file invocation preserves the existing source-only output.
+- A multi-file or directory invocation separates each source block with a
+  deterministic `==> path <==` delimiter.
+- `--write` writes changed files in place and leaves unchanged files alone.
+  Bulk writes are best effort: failures are reported with their paths while
+  other selected files continue.
+- `--check` never writes and exits nonzero if any selected file would change,
+  if discovery/formatting fails, or if no eligible files are selected. It
+  conflicts with `--write`.
+- `--time` writes per-file and total timing diagnostics to stderr. It does not
+  alter formatted stdout.
+- Bulk operations report selected, changed, written, unchanged, failed, and
+  elapsed counts on stderr.
+
+Exit status `0` means the requested operation completed successfully. Exit
+status `1` indicates an application error, a changed file in check mode, or a
+partial write failure.
+
+## Implementation boundaries
+
+`src/config.rs` owns application-level TOML loading and file-selection
+defaults. `src/discovery.rs` owns path expansion, glob matching, exclusions,
+de-duplication, and ordering. `src/formatter.rs` owns formatting and
+path-aware per-file outcomes. `src/main.rs` owns CLI output, check/write
+policy, timing, and aggregate status.

--- a/docs/validation-and-benchmarks.md
+++ b/docs/validation-and-benchmarks.md
@@ -1,0 +1,47 @@
+# Validation and local benchmarks
+
+Use the repository's Rust checks for normal changes. The focused tests cover
+configuration, discovery, CLI behavior, formatter outcomes, and fixture
+idempotency; the broader command runs the complete locked test set.
+
+```bash
+cargo test --locked --all-features
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+```
+
+The battle test is an external-corpus gate. It clones the repositories listed
+in `tests/battle_test/repos.txt` into the disposable
+`tests/battle_test/repos` directory, runs the bulk command, and retains a
+per-file diagnostic fallback for tolerated managed-package template failures.
+Use `--idempotent` to run bulk `--write` followed by bulk `--check`:
+
+```bash
+./tests/battle_test/battle_testing.sh --idempotent
+```
+
+The battle corpus is not part of the repository and requires network access,
+Git, GNU Parallel, and a Unix-like shell. Do not treat an unavailable corpus
+as a product-code failure.
+
+## Local bulk benchmark
+
+`tests/battle_test/benchmark_bulk.sh` builds `target/release/afmt` once and
+compares the legacy sequential process-per-file dry run with one bulk dry run
+over the same local corpus, config, extensions, and exclusions. It performs a
+warm-up for each mode, then five measured runs by default. The corpus is not
+modified.
+
+```bash
+AFMT_BENCH_RUNS=5 \
+  ./tests/battle_test/benchmark_bulk.sh /path/to/local/apex-repo
+```
+
+`AFMT_BENCH_RUNS` must be an odd integer of at least three so the reported
+median is unambiguous. The benchmark reports the selected file count, every
+measured run, both medians, and relative speedup. Build, clone, and download
+time is outside the measured runs. Required tools are Bash 4+, Cargo/Rust,
+`find`, `sort`, `awk`, and either nanosecond-capable `date` or Python 3.
+
+The lightweight `tests/battle_test/benchmark_bulk_test.sh` checks run-count
+validation without building the release binary.

--- a/md/TODO.md
+++ b/md/TODO.md
@@ -1,10 +1,10 @@
 # Afmt
 To-Do:
 
-- resolve idempotent issue (it's in battle_test.sh and also added use-cases into the three tests)
-- add test folders into idempotent list
+- active static, prettier80, and comments fixture idempotency coverage is complete
+- battle-test bulk write/check idempotency path is covered; retain fallback diagnostics
 - to-do folder
-- create benchmark to run locally
+- local bulk benchmark is available at tests/battle_test/benchmark_bulk.sh
 - binary exp comments
 - remove all the "pub" properties in struct/enum
 

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Node;
 
-use crate::{message_helper::red, utility::get_source_code};
+use crate::{message_helper::red, utility::with_source_code};
 
 // `c` => child
 // `cv` => child value
@@ -32,9 +32,9 @@ pub trait Accessor<'t> {
     fn next_named(&self) -> Node<'t>;
 
     // private fn;
-    fn v<'a>(&self) -> &'a str;
-    fn cv_by_k(&self, name: &str) -> &str;
-    fn cv_by_n<'a>(&self, name: &str) -> &'a str;
+    fn v(&self) -> String;
+    fn cv_by_k(&self, name: &str) -> String;
+    fn cv_by_n(&self, name: &str) -> String;
 }
 
 impl<'t> Accessor<'t> for Node<'t> {
@@ -49,13 +49,18 @@ impl<'t> Accessor<'t> for Node<'t> {
         panic!("{}: next_named node missing.", red(self.kind()));
     }
 
-    fn v<'a>(&self) -> &'a str {
-        self.utf8_text(get_source_code().as_bytes())
-            .unwrap_or_else(|_| panic!("{}: get AST source_code value failed.", red(self.kind())))
+    fn v(&self) -> String {
+        with_source_code(|source_code| {
+            self.utf8_text(source_code.as_bytes())
+                .unwrap_or_else(|_| {
+                    panic!("{}: get AST source_code value failed.", red(self.kind()))
+                })
+                .to_string()
+        })
     }
 
     fn value(&self) -> String {
-        self.v().to_string()
+        self.v()
     }
 
     fn children_vec(&self) -> Vec<Node<'t>> {
@@ -123,12 +128,12 @@ impl<'t> Accessor<'t> for Node<'t> {
         );
     }
 
-    fn cv_by_k(&self, name: &str) -> &str {
+    fn cv_by_k(&self, name: &str) -> String {
         let child_node = self.c_by_k(name);
         child_node.v()
     }
 
-    fn cv_by_n<'a>(&self, name: &str) -> &'a str {
+    fn cv_by_n(&self, name: &str) -> String {
         let node = self.child_by_field_name(name).unwrap_or_else(|| {
             panic!(
                 "## {}: missing mandatory name child: {}\n ##Source_code: {}",
@@ -141,11 +146,11 @@ impl<'t> Accessor<'t> for Node<'t> {
     }
 
     fn cvalue_by_n(&self, name: &str) -> String {
-        self.cv_by_n(name).to_string()
+        self.cv_by_n(name)
     }
 
     fn cvalue_by_k(&self, name: &str) -> String {
-        self.cv_by_k(name).to_string()
+        self.cv_by_k(name)
     }
 
     fn c_by_n(&self, name: &str) -> Node<'t> {

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,9 +1,10 @@
 use clap::{Arg as ClapArg, Command};
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct Args {
-    pub path: String,
-    pub config: Option<String>,
+    pub paths: Vec<PathBuf>,
+    pub config: Option<PathBuf>,
     pub write: bool,
     pub time: bool,
     pub check: bool,
@@ -12,23 +13,42 @@ pub struct Args {
 pub fn get_args() -> Args {
     let version = env!("CARGO_PKG_VERSION"); // read from Cargo.toml in compiling time
 
-    let matches = Command::new("afmt")
+    let matches = command(version).get_matches();
+
+    Args {
+        paths: matches
+            .get_many::<PathBuf>("path")
+            .expect("At least one path is required")
+            .cloned()
+            .collect(),
+        config: matches.get_one::<PathBuf>("config").cloned(),
+        write: matches.get_flag("write"),
+        time: matches.get_flag("time"),
+        check: matches.get_flag("check"),
+    }
+}
+
+fn command(version: &'static str) -> Command {
+    Command::new("afmt")
         .version(version)
         .about(format!("Apex format tool (afmt): {}", version))
         .arg_required_else_help(true)
         .arg(
-            ClapArg::new("file")
-                .value_name("FILE")
-                .help("The relative path to the file to parse")
+            ClapArg::new("path")
+                .value_name("PATH")
+                .help("A file or directory to format")
                 .required(true)
-                .index(1),
+                .index(1)
+                .num_args(1..)
+                .value_parser(clap::value_parser!(PathBuf)),
         )
         .arg(
             ClapArg::new("config")
                 .short('c')
                 .long("config")
                 .value_name("CONFIG")
-                .help("Path to the .afmt.toml configuration file"),
+                .help("Path to the .afmt.toml configuration file")
+                .value_parser(clap::value_parser!(PathBuf)),
         )
         .arg(
             ClapArg::new("write")
@@ -61,8 +81,14 @@ pub fn get_args() -> Args {
              # Format and write changes back to the file\n\
              afmt --write src/file.cls\n\
              \n\
+             # Format a directory recursively\n\
+             afmt --write force-app\n\
+             \n\
+             # Check mixed files and directories\n\
+             afmt --check force-app packages/shared.cls\n\
+             \n\
              # Use a specific config file\n\
-             afmt --config .afmt.toml ./file.cls\n\
+             afmt --config .afmt.toml --time --write .\n\
              \n\
              # Display execution time after formatting\n\
              afmt --time ./file.cls\n\
@@ -71,16 +97,30 @@ pub fn get_args() -> Args {
              afmt --check ./file.cls\n\
             ",
         )
-        .get_matches();
+}
 
-    Args {
-        path: matches
-            .get_one::<String>("file")
-            .expect("File path is required")
-            .to_string(),
-        config: matches.get_one::<String>("config").map(|s| s.to_string()),
-        write: matches.get_flag("write"),
-        time: matches.get_flag("time"),
-        check: matches.get_flag("check"),
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_one_or_more_path_values() {
+        let matches = command("test")
+            .try_get_matches_from(["afmt", "one.cls", "nested", "two.apex"])
+            .unwrap();
+        let paths = matches
+            .get_many::<PathBuf>("path")
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("one.cls"),
+                PathBuf::from("nested"),
+                PathBuf::from("two.apex")
+            ]
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,118 @@
+use crate::formatter::Config;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_INCLUDES: &[&str] = &["**/*.cls", "**/*.trigger", "**/*.apex", "**/*.apexc"];
+const DEFAULT_EXCLUDES: &[&str] = &["**/.git/**", "**/.sfdx/**", "**/node_modules/**"];
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct AfmtConfig {
+    #[serde(flatten)]
+    pub formatter: Config,
+    #[serde(default)]
+    pub files: FileSelectionConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct FileSelectionConfig {
+    #[serde(default = "default_includes")]
+    pub include: Vec<String>,
+    #[serde(default = "default_excludes")]
+    pub exclude: Vec<String>,
+}
+
+impl Default for FileSelectionConfig {
+    fn default() -> Self {
+        Self {
+            include: default_includes(),
+            exclude: default_excludes(),
+        }
+    }
+}
+
+impl AfmtConfig {
+    pub fn from_file(path: &Path) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path).map_err(|error| {
+            format!("Failed to read config file: {}: {}", path.display(), error)
+        })?;
+        toml::from_str(&content)
+            .map_err(|error| format!("Failed to parse config file: {}: {}", path.display(), error))
+    }
+
+    pub fn load(path: Option<&Path>) -> Result<Self, String> {
+        path.map_or_else(|| Ok(Self::default()), Self::from_file)
+    }
+
+    pub fn base_dir(config_path: Option<&Path>) -> Result<PathBuf, String> {
+        match config_path {
+            Some(path) => path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .map_or_else(
+                    || std::env::current_dir().map_err(|error| error.to_string()),
+                    |parent| {
+                        let base = if parent.is_absolute() {
+                            parent.to_path_buf()
+                        } else {
+                            std::env::current_dir()
+                                .map_err(|error| error.to_string())?
+                                .join(parent)
+                        };
+                        std::fs::canonicalize(&base).map_err(|error| {
+                            format!(
+                                "Failed to resolve config directory {}: {}",
+                                base.display(),
+                                error
+                            )
+                        })
+                    },
+                ),
+            None => std::env::current_dir().map_err(|error| error.to_string()),
+        }
+    }
+}
+
+fn default_includes() -> Vec<String> {
+    DEFAULT_INCLUDES
+        .iter()
+        .map(|pattern| (*pattern).to_string())
+        .collect()
+}
+
+fn default_excludes() -> Vec<String> {
+    DEFAULT_EXCLUDES
+        .iter()
+        .map(|pattern| (*pattern).to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn old_two_key_config_uses_default_file_selection() {
+        let config: AfmtConfig = toml::from_str("max_width = 100\nindent_size = 4\n").unwrap();
+
+        assert_eq!(config.formatter.max_width, 100);
+        assert_eq!(config.formatter.indent_size, 4);
+        assert_eq!(config.files, FileSelectionConfig::default());
+    }
+
+    #[test]
+    fn custom_file_selection_replaces_each_default_array() {
+        let config: AfmtConfig =
+            toml::from_str("[files]\ninclude = [\"**/*.foo\"]\nexclude = []\n").unwrap();
+
+        assert_eq!(config.files.include, vec!["**/*.foo"]);
+        assert!(config.files.exclude.is_empty());
+    }
+
+    #[test]
+    fn omitted_file_selection_arrays_default_independently() {
+        let config: AfmtConfig = toml::from_str("[files]\nexclude = []\n").unwrap();
+
+        assert_eq!(config.files.include, FileSelectionConfig::default().include);
+        assert!(config.files.exclude.is_empty());
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -133,6 +133,10 @@ impl Comment {
     pub fn is_printed(&self) -> bool {
         self.is_printed.get()
     }
+
+    pub fn mark_as_inline_post_comment(&mut self) {
+        self.metadata.has_leading_content = true;
+    }
 }
 
 impl<'a> DocBuild<'a> for Comment {

--- a/src/context.rs
+++ b/src/context.rs
@@ -147,6 +147,11 @@ impl<'a> DocBuild<'a> for Comment {
 
                 // JavaDoc formatting
                 if self.value.starts_with("/**") {
+                    let star = match b.config.javadoc_star_column {
+                        crate::doc::JavadocStarColumn::Offset => " *",
+                        crate::doc::JavadocStarColumn::Flush => "*",
+                    };
+
                     // Handle the first line that might contain both /** and content
                     if !lines.is_empty() {
                         let first_line = lines[0].trim();
@@ -173,18 +178,18 @@ impl<'a> DocBuild<'a> for Comment {
                             if let Some(before_end) = trimmed.strip_suffix("*/") {
                                 let content = before_end.trim();
                                 if content.is_empty() {
-                                    result.push(b.txt(" */"));
+                                    result.push(b.txt(format!("{star}/")));
                                 } else {
-                                    result.push(b.txt(format!(" * {}", content))); // First line: Preserve content
+                                    result.push(b.txt(format!("{star} {content}"))); // First line: Preserve content
                                     result.push(b.nl()); // Newline before closing */
-                                    result.push(b.txt(" */")); // Second line: Properly close the comment
+                                    result.push(b.txt(format!("{star}/"))); // Second line: Properly close the comment
                                 }
                             } else {
-                                result.push(b.txt(" */")); // Fallback (shouldn't happen in valid JavaDoc)
+                                result.push(b.txt(format!("{star}/"))); // Fallback (shouldn't happen in valid JavaDoc)
                             }
                         } else if trimmed.is_empty() {
                             // Handle empty lines
-                            result.push(b.txt(" *"));
+                            result.push(b.txt(star));
                         } else {
                             // Handle content lines
                             if let Some(after_star) = trimmed.strip_prefix('*') {
@@ -192,14 +197,14 @@ impl<'a> DocBuild<'a> for Comment {
                                 let content = after_star.trim_start(); // Remove all leading spaces
                                 if content.is_empty() {
                                     // Just a star with no content
-                                    result.push(b.txt(" *"));
+                                    result.push(b.txt(star));
                                 } else {
                                     // Star with content - add exactly one space
-                                    result.push(b.txt(format!(" * {}", content)));
+                                    result.push(b.txt(format!("{star} {content}")));
                                 }
                             } else {
                                 // Line doesn't have a star, add standard formatting
-                                result.push(b.txt(format!(" * {}", trimmed)));
+                                result.push(b.txt(format!("{star} {trimmed}")));
                             }
                         }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, collections::HashMap};
+use std::{cell::Cell, collections::HashMap, rc::Rc};
 use tree_sitter::Node;
 
 use crate::{
@@ -45,7 +45,7 @@ impl NodeContext {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommentBucket {
     pub pre_comments: Vec<Comment>,
     pub post_comments: Vec<Comment>,
@@ -74,7 +74,7 @@ pub struct Comment {
     pub value: String,
     pub comment_type: CommentType,
     pub metadata: CommentMetadata,
-    pub is_printed: Cell<bool>,
+    pub is_printed: Rc<Cell<bool>>,
 }
 
 impl Comment {
@@ -98,7 +98,7 @@ impl Comment {
             value,
             comment_type,
             metadata,
-            is_printed: Cell::new(false),
+            is_printed: Rc::new(Cell::new(false)),
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -333,22 +333,25 @@ impl Punctuation {
         }
         None
     }
-}
 
-impl<'a> DocBuild<'a> for Punctuation {
-    fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
-        // TODO: merge into normal bucket handling utiltiy method?
+    pub fn build_comments<'a>(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
+        self.build_inner_with_token(b, result, false);
+    }
 
+    fn build_inner_with_token<'a>(
+        &self,
+        b: &'a DocBuilder<'a>,
+        result: &mut Vec<DocRef<'a>>,
+        include_token: bool,
+    ) {
         let bucket = get_comment_bucket(&self.id);
 
-        // Separate line comments and block comments from pre_comments
         let (line_comments_in_pre, block_comments_in_pre): (Vec<Comment>, Vec<Comment>) = bucket
             .pre_comments
             .iter()
             .cloned()
             .partition(|comment| matches!(comment.comment_type, CommentType::Line));
 
-        // Merge line_comments with post_comments
         let updated_post_comments: Vec<_> = line_comments_in_pre
             .into_iter()
             .chain(bucket.post_comments.iter().cloned())
@@ -370,9 +373,11 @@ impl<'a> DocBuild<'a> for Punctuation {
             }
         }
 
-        match self.type_ {
-            PuncuationType::Comma => result.push(b.txt(",")),
-            PuncuationType::Semicolon => result.push(b.txt(";")),
+        if include_token {
+            match self.type_ {
+                PuncuationType::Comma => result.push(b.txt(",")),
+                PuncuationType::Semicolon => result.push(b.txt(";")),
+            }
         }
 
         for comment in updated_post_comments {
@@ -391,14 +396,18 @@ impl<'a> DocBuild<'a> for Punctuation {
             }
         }
 
-        // we assume all associated comment nodes are handled
-        // TODO: this is not ideal due to the comment map is currently defined read-only
         for comment in &bucket.pre_comments {
             comment.mark_as_printed();
         }
         for comment in &bucket.post_comments {
             comment.mark_as_printed();
         }
+    }
+}
+
+impl<'a> DocBuild<'a> for Punctuation {
+    fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
+        self.build_inner_with_token(b, result, true);
     }
 }
 

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -1,6 +1,6 @@
 use crate::{
     accessor::Accessor,
-    context::{NodeContext, Punctuation},
+    context::{CommentType, NodeContext, Punctuation},
     doc::DocRef,
     doc_builder::{DocBuilder, Insertable},
     enum_def::*,
@@ -825,10 +825,25 @@ impl<'a> DocBuild<'a> for MethodInvocationKind {
             } => {
                 let mut docs = vec![];
                 docs.push(object.build(b));
+                let name_bucket = get_comment_bucket(&name.node_context.id);
+                let has_line_pre_comment = name_bucket
+                    .pre_comments
+                    .iter()
+                    .any(|comment| matches!(comment.comment_type, CommentType::Line));
+
+                if has_line_pre_comment {
+                    docs.push(b.nl());
+                    let mut hoisted_comments = Vec::new();
+                    handle_pre_comments(b, name_bucket, &mut hoisted_comments);
+                    docs.extend(hoisted_comments);
+                }
 
                 // potential chaining scenario
                 if let Some(context) = context {
-                    if context.is_parent_a_chaining_node || context.is_top_most_in_a_chain {
+                    let is_chaining =
+                        context.is_parent_a_chaining_node || context.is_top_most_in_a_chain;
+
+                    if is_chaining && !has_line_pre_comment {
                         docs.push(b.maybeline());
                     }
 
@@ -838,7 +853,11 @@ impl<'a> DocBuild<'a> for MethodInvocationKind {
                         docs.push(n.build(b));
                     }
 
-                    docs.push(name.build(b));
+                    if has_line_pre_comment {
+                        docs.push(name.build_without_pre_comments(b));
+                    } else {
+                        docs.push(name.build(b));
+                    }
                     docs.push(arguments.build(b));
 
                     if context.is_top_most_in_a_chain {
@@ -852,7 +871,11 @@ impl<'a> DocBuild<'a> for MethodInvocationKind {
                     if let Some(ref n) = type_arguments {
                         docs.push(n.build(b));
                     }
-                    docs.push(name.build(b));
+                    if has_line_pre_comment {
+                        docs.push(name.build_without_pre_comments(b));
+                    } else {
+                        docs.push(name.build(b));
+                    }
                     docs.push(arguments.build(b));
                     result.push(b.concat(docs))
                 }
@@ -5588,6 +5611,24 @@ impl ValueNode {
             value: node.value(),
             node_context: NodeContext::with_punctuation(&node),
         }
+    }
+
+    fn build_without_pre_comments<'a>(&self, b: &'a DocBuilder<'a>) -> DocRef<'a> {
+        let bucket = get_comment_bucket(&self.node_context.id);
+        let mut result = Vec::new();
+
+        if bucket.dangling_comments.is_empty() {
+            result.push(b.txt(&self.value));
+            handle_post_comments(b, bucket, &mut result);
+        } else {
+            result.push(b.concat(handle_dangling_comments(b, bucket)));
+        }
+
+        if let Some(ref punctuation) = self.node_context.punc {
+            result.push(punctuation.build(b));
+        }
+
+        b.concat(result)
     }
 }
 

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -445,13 +445,13 @@ impl ClassBody {
 impl<'a> DocBuild<'a> for ClassBody {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         let bucket = get_comment_bucket(&self.node_context.id);
-        handle_pre_comments(b, bucket, result);
+        handle_pre_comments(b, &bucket, result);
 
         if bucket.dangling_comments.is_empty() {
             result.push(b.surround_body_members(&self.class_members, "{", "}"));
-            handle_post_comments(b, bucket, result);
+            handle_post_comments(b, &bucket, result);
         } else {
-            handle_dangling_comments_in_bracket_surround(b, bucket, result);
+            handle_dangling_comments_in_bracket_surround(b, &bucket, result);
         }
     }
 }
@@ -600,6 +600,8 @@ impl<'a> DocBuild<'a> for AssignmentExpression {
 }
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum AssignmentLeft {
     Identifier(ValueNode),
     Field(FieldAccess),
@@ -683,16 +685,16 @@ impl Block {
 impl<'a> DocBuild<'a> for Block {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         let bucket = get_comment_bucket(&self.node_context.id);
-        handle_pre_comments(b, bucket, result);
+        handle_pre_comments(b, &bucket, result);
 
         if bucket.dangling_comments.is_empty() {
             let docs = b.surround_body_members(&self.statements, "{", "}");
             result.push(docs);
         } else {
-            handle_dangling_comments_in_bracket_surround(b, bucket, result);
+            handle_dangling_comments_in_bracket_surround(b, &bucket, result);
             return;
         }
-        handle_post_comments(b, bucket, result);
+        handle_post_comments(b, &bucket, result);
     }
 }
 
@@ -1421,6 +1423,8 @@ impl<'a> DocBuild<'a> for ParenthesizedExpression {
 }
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum ForInitOption {
     Declaration(LocalVariableDeclaration),
     Exps(Vec<Expression>),
@@ -1805,7 +1809,7 @@ impl ConstructorBody {
 impl<'a> DocBuild<'a> for ConstructorBody {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         let bucket = get_comment_bucket(&self.node_context.id);
-        handle_pre_comments(b, bucket, result);
+        handle_pre_comments(b, &bucket, result);
 
         if bucket.dangling_comments.is_empty() {
             if self.constructor_invocation.is_none() && self.statements.is_empty() {
@@ -1832,7 +1836,7 @@ impl<'a> DocBuild<'a> for ConstructorBody {
             result.push(b.nl());
             result.push(b.txt("}"));
         } else {
-            handle_dangling_comments_in_bracket_surround(b, bucket, result);
+            handle_dangling_comments_in_bracket_surround(b, &bucket, result);
         }
     }
 }
@@ -2319,7 +2323,7 @@ impl EnumBody {
 impl<'a> DocBuild<'a> for EnumBody {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         let bucket = get_comment_bucket(&self.node_context.id);
-        handle_pre_comments(b, bucket, result);
+        handle_pre_comments(b, &bucket, result);
 
         if bucket.dangling_comments.is_empty() {
             let docs = b.to_docs(&self.enum_constants);
@@ -2333,9 +2337,9 @@ impl<'a> DocBuild<'a> for EnumBody {
             let close = Insertable::new(Some(b.nl()), Some("}"), None);
             let doc = b.group_surround(&docs, sep, open, close);
             result.push(doc);
-            handle_post_comments(b, bucket, result);
+            handle_post_comments(b, &bucket, result);
         } else {
-            handle_dangling_comments_in_bracket_surround(b, bucket, result);
+            handle_dangling_comments_in_bracket_surround(b, &bucket, result);
         }
     }
 }
@@ -2600,27 +2604,31 @@ impl ArrayCreationExpression {
         let value_node = node.try_c_by_n("value");
         let dimensions_node = node.try_c_by_n("dimensions");
 
-        let variant = if value_node.is_none() {
-            // DD
-            let dimensions_exprs = node
-                .cs_by_k("dimensions_expr")
-                .into_iter()
-                .map(|n| DimensionsExpr::new(n))
-                .collect();
-            let dimensions = node.try_c_by_k("dimensions").map(|n| Dimensions::new(n));
-            ArrayCreationVariant::DD {
-                dimensions_exprs,
-                dimensions,
+        let variant = match (value_node, dimensions_node) {
+            (None, _) => {
+                // DD
+                let dimensions_exprs = node
+                    .cs_by_k("dimensions_expr")
+                    .into_iter()
+                    .map(|n| DimensionsExpr::new(n))
+                    .collect();
+                let dimensions = node.try_c_by_k("dimensions").map(|n| Dimensions::new(n));
+                ArrayCreationVariant::DD {
+                    dimensions_exprs,
+                    dimensions,
+                }
             }
-        } else if dimensions_node.is_none() {
-            //OnlyV
-            let value = ArrayInitializer::new(node.c_by_n("value"));
-            ArrayCreationVariant::OnlyV { value }
-        } else {
-            //DV
-            ArrayCreationVariant::DV {
-                value: ArrayInitializer::new(value_node.unwrap()),
-                dimensions: Dimensions::new(dimensions_node.unwrap()),
+            (Some(value_node), None) => {
+                // OnlyV
+                let value = ArrayInitializer::new(value_node);
+                ArrayCreationVariant::OnlyV { value }
+            }
+            (Some(value_node), Some(dimensions_node)) => {
+                // DV
+                ArrayCreationVariant::DV {
+                    value: ArrayInitializer::new(value_node),
+                    dimensions: Dimensions::new(dimensions_node),
+                }
             }
         };
 
@@ -3082,13 +3090,13 @@ impl InterfaceBody {
 impl<'a> DocBuild<'a> for InterfaceBody {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         let bucket = get_comment_bucket(&self.node_context.id);
-        handle_pre_comments(b, bucket, result);
+        handle_pre_comments(b, &bucket, result);
 
         if bucket.dangling_comments.is_empty() {
             result.push(b.surround_body_members(&self.members, "{", "}"));
-            handle_post_comments(b, bucket, result);
+            handle_post_comments(b, &bucket, result);
         } else {
-            handle_dangling_comments_in_bracket_surround(b, bucket, result);
+            handle_dangling_comments_in_bracket_surround(b, &bucket, result);
         }
     }
 }
@@ -3880,6 +3888,8 @@ impl<'a> DocBuild<'a> for QueryExpression {
 }
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum QueryBody {
     Soql(SoqlQueryBody),
     Sosl(SoslQueryBody),
@@ -5076,6 +5086,8 @@ impl<'a> DocBuild<'a> for GroupByClause {
 }
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum GroupByExpression {
     Field(FieldIdentifier),
     Func(FunctionExpression),

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -123,9 +123,10 @@ impl<'a> DocBuild<'a> for ClassDeclaration {
                 docs.push(n.build(b));
             }
 
-            docs.push(b.txt(" "));
             result.push(b.group_indent_concat(docs));
-
+            // Separator lives outside the group: newlines (Allman) can't compose
+            // with group(...). In K&R this is the same trailing space as before.
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }
@@ -170,7 +171,7 @@ impl<'a> DocBuild<'a> for MethodDeclaration {
             result.push(self.formal_parameters.build(b));
 
             if let Some(ref n) = self.body {
-                result.push(b.txt(" "));
+                result.push(b.body_open_sep());
                 let body_doc = n.build(b);
                 result.push(body_doc);
             }
@@ -513,7 +514,7 @@ impl<'a> DocBuild<'a> for FieldDeclaration {
             result.push(doc);
 
             if let Some(ref n) = self.accessor_list {
-                result.push(b.txt(" "));
+                result.push(b.body_open_sep());
                 result.push(n.build(b));
             }
         });
@@ -1357,33 +1358,54 @@ impl<'a> DocBuild<'a> for IfStatement {
             result.push(b.txt("if "));
             result.push(self.condition.build(b));
 
-            if self.consequence.is_block() {
-                result.push(b.txt(" "));
-                result.push(self.consequence.build(b));
+            // Consequence body. `if` style: a brace-less single statement breaks
+            // onto its own indented line.
+            if matches!(self.consequence, Statement::SemiColumn) && b.wraps_single() {
+                result.push(b.empty_clause_body());
             } else {
-                result.push(b.indent(b.nl()));
-                result.push(b.indent(self.consequence.build(b)));
+                result.push(b.clause_body(
+                    self.consequence.build(b),
+                    self.consequence.is_block(),
+                    true,
+                ));
             }
 
-            // Handle the 'else' part
-            if let Some(ref alt) = self.alternative {
-                if self.consequence.is_block() {
-                    result.push(b.txt(" "));
+            // Did the consequence render a closing brace on its own line — a real
+            // block, or a single statement we wrapped in braces?
+            let cons_braced = self.consequence.is_block() || b.wraps_single();
 
-                    result.push(alt.else_node.build(b));
-                    result.push(b.txt(" "));
+            // Handle the 'else' part.
+            if let Some(ref alt) = self.alternative {
+                // Separator between the end of the consequence and `else`.
+                if cons_braced {
+                    result.push(b.body_open_sep());
                 } else {
                     result.push(b.nl());
+                }
+                result.push(alt.else_node.build(b));
 
-                    result.push(alt.else_node.build(b));
-
-                    if !matches!(alt.statement, Statement::If(_) | Statement::Block(_)) {
-                        result.push(b.indent(b.nl()));
-                    } else {
+                match alt.statement {
+                    // `else if (...)`: keep the chain inline in every style.
+                    Statement::If(_) => {
                         result.push(b.txt(" "));
+                        result.push(alt.statement.build(b));
+                    }
+                    // `else { ... }`: block body, brace placement per style.
+                    Statement::Block(_) => {
+                        result.push(b.body_open_sep());
+                        result.push(alt.statement.build(b));
+                    }
+                    // Single-statement else. Legacy fallback differs by context:
+                    // after a braced consequence it hugs the line (`} else y;`),
+                    // after a brace-less one it breaks (`else\n  y;`).
+                    _ => {
+                        if matches!(alt.statement, Statement::SemiColumn) && b.wraps_single() {
+                            result.push(b.empty_clause_body());
+                        } else {
+                            result.push(b.clause_body(alt.statement.build(b), false, !cons_braced));
+                        }
                     }
                 }
-                result.push(alt.statement.build(b));
             }
         });
     }
@@ -1401,6 +1423,24 @@ impl ParenthesizedExpression {
             exp: Expression::new(node.first_c()),
             node_context: NodeContext::with_punctuation(&node),
         }
+    }
+
+    pub fn build_without_punctuation<'a>(&self, b: &'a DocBuilder<'a>) -> DocRef<'a> {
+        let mut result = Vec::new();
+        build_with_comments(b, &self.node_context, &mut result, |b, result| {
+            result.push(b.txt("("));
+            let doc = b.concat(vec![
+                b.indent(b.maybeline()),
+                b.indent(self.exp.build(b)),
+                b.maybeline(),
+            ]);
+            result.push(b.group(doc));
+            result.push(b.txt(")"));
+        });
+        if let Some(ref punctuation) = self.node_context.punc {
+            punctuation.build_comments(b, &mut result);
+        }
+        b.concat(result)
     }
 }
 
@@ -1543,10 +1583,16 @@ impl<'a> DocBuild<'a> for ForStatement {
             result.push(doc);
 
             match self.body {
-                Statement::SemiColumn => result.push(b.txt(";")),
+                Statement::SemiColumn => {
+                    if b.wraps_single() {
+                        result.push(b.empty_clause_body());
+                    } else {
+                        result.push(b.txt(";"));
+                    }
+                }
                 _ => {
-                    result.push(b.txt(" "));
-                    result.push(self.body.build(b));
+                    // Loop style: a brace-less single body stays inline.
+                    result.push(b.clause_body(self.body.build(b), self.body.is_block(), false));
                 }
             }
         });
@@ -1592,10 +1638,16 @@ impl<'a> DocBuild<'a> for EnhancedForStatement {
             result.push(self.value.build(b));
             result.push(b.txt(")"));
             match self.body {
-                Statement::SemiColumn => result.push(b.txt(";")),
+                Statement::SemiColumn => {
+                    if b.wraps_single() {
+                        result.push(b.empty_clause_body());
+                    } else {
+                        result.push(b.txt(";"));
+                    }
+                }
                 _ => {
-                    result.push(b.txt(" "));
-                    result.push(self.body.build(b));
+                    // Loop style: a brace-less single body stays inline.
+                    result.push(b.clause_body(self.body.build(b), self.body.is_block(), false));
                 }
             }
         });
@@ -1768,7 +1820,7 @@ impl<'a> DocBuild<'a> for ConstructorDeclaration {
 
             result.push(self.name.build(b));
             result.push(self.parameters.build(b));
-            result.push(b.txt(" "));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }
@@ -2052,7 +2104,7 @@ impl<'a> DocBuild<'a> for RunAsStatement {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
             result.push(b.txt("System.runAs"));
             result.push(self.user.build(b));
-            result.push(b.txt(" "));
+            result.push(b.body_open_sep());
             result.push(self.block.build(b));
         });
     }
@@ -2081,9 +2133,11 @@ impl DoStatement {
 impl<'a> DocBuild<'a> for DoStatement {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b.txt_("do"));
+            result.push(b.txt("do"));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
-            result.push(b._txt_("while"));
+            result.push(b.body_open_sep());
+            result.push(b.txt_("while"));
             result.push(self.condition.build(b));
         });
     }
@@ -2112,13 +2166,20 @@ impl<'a> DocBuild<'a> for WhileStatement {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments(b, &self.node_context, result, |b, result| {
             result.push(b.txt_("while"));
-            result.push(self.condition.build(b));
+            let condition = if matches!(self.body, Statement::SemiColumn) && b.wraps_single() {
+                self.condition.build_without_punctuation(b)
+            } else {
+                self.condition.build(b)
+            };
+            result.push(condition);
 
             match self.body {
-                Statement::SemiColumn => {}
+                Statement::SemiColumn => {
+                    result.push(b.empty_clause_body());
+                }
                 _ => {
-                    result.push(b.txt(" "));
-                    result.push(self.body.build(b));
+                    // Loop style: a brace-less single body stays inline.
+                    result.push(b.clause_body(self.body.build(b), self.body.is_block(), false));
                 }
             }
         });
@@ -2283,11 +2344,12 @@ impl<'a> DocBuild<'a> for EnumDeclaration {
             }
             result.push(b.txt_("enum"));
             result.push(self.name.build(b));
-            result.push(b.txt(" "));
 
             if let Some(ref n) = self.interface {
+                result.push(b.txt(" "));
                 result.push(n.build(b));
             }
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }
@@ -2847,7 +2909,8 @@ impl TryStatement {
 impl<'a> DocBuild<'a> for TryStatement {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b.txt_("try"));
+            result.push(b.txt("try"));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
             result.push(self.tail.build(b));
         });
@@ -2864,14 +2927,21 @@ impl<'a> DocBuild<'a> for TryStatementTail {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         match self {
             Self::Catches(v) => {
-                let docs = b.to_docs(v);
+                let docs: Vec<DocRef<'a>> = v
+                    .iter()
+                    .flat_map(|catch| [b.clause_sep(), catch.build(b)])
+                    .collect();
                 let catches_doc = b.concat(docs);
                 result.push(catches_doc);
             }
             Self::CatchesFinally(v, f) => {
-                let docs = b.to_docs(v);
+                let docs: Vec<DocRef<'a>> = v
+                    .iter()
+                    .flat_map(|catch| [b.clause_sep(), catch.build(b)])
+                    .collect();
                 let catches_doc = b.concat(docs);
                 result.push(catches_doc);
+                result.push(b.clause_sep());
                 result.push(f.build(b));
             }
         }
@@ -2900,11 +2970,12 @@ impl CatchClause {
 impl<'a> DocBuild<'a> for CatchClause {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b._txt_("catch"));
+            result.push(b.txt("catch "));
 
             result.push(b.txt("("));
             result.push(self.formal_parameter.build(b));
-            result.push(b.txt_(")"));
+            result.push(b.txt(")"));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }
@@ -2930,7 +3001,8 @@ impl FinallyClause {
 impl<'a> DocBuild<'a> for FinallyClause {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b._txt_("finally"));
+            result.push(b.txt("finally"));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }
@@ -2954,7 +3026,8 @@ impl StaticInitializer {
 impl<'a> DocBuild<'a> for StaticInitializer {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b.txt_("static"));
+            result.push(b.txt("static"));
+            result.push(b.body_open_sep());
             result.push(self.block.build(b));
         });
     }
@@ -3010,7 +3083,7 @@ impl<'a> DocBuild<'a> for InterfaceDeclaration {
                 result.push(n.build(b));
             }
 
-            result.push(b.txt(" "));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }
@@ -3254,7 +3327,7 @@ impl<'a> DocBuild<'a> for AccessorDeclaration {
             result.push(b.txt(&self.accessor));
 
             if let Some(ref n) = self.body {
-                result.push(b.txt(" "));
+                result.push(b.body_open_sep());
                 result.push(n.build(b));
             }
         });
@@ -3424,7 +3497,7 @@ impl<'a> DocBuild<'a> for SwitchExpression {
             let docs = vec![b.txt("switch on"), b.softline(), self.condition.build(b)];
             let doc = b.group_indent_concat(docs);
             result.push(doc);
-            result.push(b.txt(" "));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }
@@ -3490,7 +3563,7 @@ impl<'a> DocBuild<'a> for SwitchRule {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
             result.push(self.label.build(b));
-            result.push(b.txt(" "));
+            result.push(b.body_open_sep());
             result.push(self.block.build(b));
         });
     }
@@ -3769,7 +3842,7 @@ impl<'a> DocBuild<'a> for TriggerDeclaration {
             let doc = b.group_surround(&docs, sep, open, close);
             result.push(doc);
 
-            result.push(b.txt(" "));
+            result.push(b.body_open_sep());
             result.push(self.body.build(b));
         });
     }

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -376,11 +376,46 @@ impl Annotation {
     }
 }
 
+fn canonical_annotation_name(name: &str) -> Option<&'static str> {
+    let lowercase_name = name.to_ascii_lowercase();
+
+    match lowercase_name.as_str() {
+        "istest" => Some("IsTest"),
+        "testsetup" => Some("TestSetup"),
+        "testvisible" => Some("TestVisible"),
+        "auraenabled" => Some("AuraEnabled"),
+        "future" => Some("Future"),
+        "invocablemethod" => Some("InvocableMethod"),
+        "invocablevariable" => Some("InvocableVariable"),
+        "httpget" => Some("HttpGet"),
+        "httppost" => Some("HttpPost"),
+        "httpput" => Some("HttpPut"),
+        "httppatch" => Some("HttpPatch"),
+        "httpdelete" => Some("HttpDelete"),
+        "restresource" => Some("RestResource"),
+        "readonly" => Some("ReadOnly"),
+        "remoteaction" => Some("RemoteAction"),
+        "deprecated" => Some("Deprecated"),
+        "suppresswarnings" => Some("SuppressWarnings"),
+        "namespaceaccessible" => Some("NamespaceAccessible"),
+        "jsonaccess" => Some("JsonAccess"),
+        _ => None,
+    }
+}
+
 impl<'a> DocBuild<'a> for Annotation {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
             result.push(b.txt("@"));
-            result.push(self.name.build(b));
+            if b.normalizes_annotation_casing() {
+                if let Some(canonical_name) = canonical_annotation_name(&self.name.value) {
+                    self.name.build_value(b, result, canonical_name);
+                } else {
+                    result.push(self.name.build(b));
+                }
+            } else {
+                result.push(self.name.build(b));
+            }
 
             if let Some(a) = &self.arguments {
                 result.push(a.build(b));
@@ -5662,13 +5697,17 @@ impl ValueNode {
             node_context: NodeContext::with_punctuation(&node),
         }
     }
+
+    fn build_value<'a>(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>, value: &str) {
+        build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
+            result.push(b.txt(value));
+        });
+    }
 }
 
 impl<'a> DocBuild<'a> for ValueNode {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
-        build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b.txt(&self.value));
-        });
+        self.build_value(b, result, &self.value);
     }
 }
 

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -600,6 +600,7 @@ impl<'a> DocBuild<'a> for AssignmentExpression {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum AssignmentLeft {
     Identifier(ValueNode),
     Field(FieldAccess),
@@ -1421,6 +1422,7 @@ impl<'a> DocBuild<'a> for ParenthesizedExpression {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ForInitOption {
     Declaration(LocalVariableDeclaration),
     Exps(Vec<Expression>),
@@ -2600,27 +2602,31 @@ impl ArrayCreationExpression {
         let value_node = node.try_c_by_n("value");
         let dimensions_node = node.try_c_by_n("dimensions");
 
-        let variant = if value_node.is_none() {
-            // DD
-            let dimensions_exprs = node
-                .cs_by_k("dimensions_expr")
-                .into_iter()
-                .map(|n| DimensionsExpr::new(n))
-                .collect();
-            let dimensions = node.try_c_by_k("dimensions").map(|n| Dimensions::new(n));
-            ArrayCreationVariant::DD {
-                dimensions_exprs,
-                dimensions,
+        let variant = match (value_node, dimensions_node) {
+            (None, _) => {
+                // DD
+                let dimensions_exprs = node
+                    .cs_by_k("dimensions_expr")
+                    .into_iter()
+                    .map(|n| DimensionsExpr::new(n))
+                    .collect();
+                let dimensions = node.try_c_by_k("dimensions").map(|n| Dimensions::new(n));
+                ArrayCreationVariant::DD {
+                    dimensions_exprs,
+                    dimensions,
+                }
             }
-        } else if dimensions_node.is_none() {
-            //OnlyV
-            let value = ArrayInitializer::new(node.c_by_n("value"));
-            ArrayCreationVariant::OnlyV { value }
-        } else {
-            //DV
-            ArrayCreationVariant::DV {
-                value: ArrayInitializer::new(value_node.unwrap()),
-                dimensions: Dimensions::new(dimensions_node.unwrap()),
+            (Some(value_node), None) => {
+                // OnlyV
+                let value = ArrayInitializer::new(value_node);
+                ArrayCreationVariant::OnlyV { value }
+            }
+            (Some(value_node), Some(dimensions_node)) => {
+                // DV
+                ArrayCreationVariant::DV {
+                    value: ArrayInitializer::new(value_node),
+                    dimensions: Dimensions::new(dimensions_node),
+                }
             }
         };
 
@@ -3880,6 +3886,7 @@ impl<'a> DocBuild<'a> for QueryExpression {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum QueryBody {
     Soql(SoqlQueryBody),
     Sosl(SoslQueryBody),
@@ -5076,6 +5083,7 @@ impl<'a> DocBuild<'a> for GroupByClause {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum GroupByExpression {
     Field(FieldIdentifier),
     Func(FunctionExpression),

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,533 @@
+use crate::config::FileSelectionConfig;
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::collections::HashSet;
+use std::fmt::{Display, Formatter};
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiscoveryError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl Display for DiscoveryError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.path.display(), self.message)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiscoveryConfigError {
+    InvalidPattern {
+        kind: &'static str,
+        pattern: String,
+        message: String,
+    },
+    InputMissing(PathBuf),
+    InputError {
+        path: PathBuf,
+        message: String,
+    },
+    InputUnsupported(PathBuf),
+    NoMatches,
+}
+
+impl Display for DiscoveryConfigError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPattern {
+                kind,
+                pattern,
+                message,
+            } => {
+                write!(
+                    formatter,
+                    "Invalid {} glob {:?}: {}",
+                    kind, pattern, message
+                )
+            }
+            Self::InputMissing(path) => {
+                write!(formatter, "Input path does not exist: {}", path.display())
+            }
+            Self::InputError { path, message } => write!(
+                formatter,
+                "Failed to inspect input {}: {}",
+                path.display(),
+                message
+            ),
+            Self::InputUnsupported(path) => write!(
+                formatter,
+                "Input path is not a file or directory: {}",
+                path.display()
+            ),
+            Self::NoMatches => write!(formatter, "No eligible Apex files were found"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiscoveryReport {
+    pub files: Vec<PathBuf>,
+    pub errors: Vec<DiscoveryError>,
+}
+
+pub fn discover_targets(
+    targets: &[PathBuf],
+    selection: &FileSelectionConfig,
+    base: &Path,
+) -> Result<DiscoveryReport, DiscoveryConfigError> {
+    let includes = compile_globs("include", &selection.include)?;
+    let excludes = compile_globs("exclude", &selection.exclude)?;
+    let mut accumulator = DiscoveryAccumulator::new(base, includes, excludes);
+
+    for target in targets {
+        let metadata = fs::symlink_metadata(target).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                DiscoveryConfigError::InputMissing(target.clone())
+            } else {
+                DiscoveryConfigError::InputError {
+                    path: target.clone(),
+                    message: error.to_string(),
+                }
+            }
+        })?;
+
+        if metadata.is_file() {
+            accumulator.consider_file(target, false);
+        } else if metadata.is_dir() {
+            for entry in WalkDir::new(target).follow_links(false).into_iter() {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(error) => {
+                        record_traversal_error(&mut accumulator.errors, target, &error);
+                        continue;
+                    }
+                };
+
+                if entry.file_type().is_file() {
+                    accumulator.consider_file(entry.path(), true);
+                }
+            }
+        } else {
+            return Err(DiscoveryConfigError::InputUnsupported(target.clone()));
+        }
+    }
+
+    accumulator.files.sort_by_key(|path| display_path(path));
+    if accumulator.files.is_empty() {
+        return Err(DiscoveryConfigError::NoMatches);
+    }
+
+    Ok(DiscoveryReport {
+        files: accumulator.files,
+        errors: accumulator.errors,
+    })
+}
+
+fn compile_globs(kind: &'static str, patterns: &[String]) -> Result<GlobSet, DiscoveryConfigError> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        let normalized = pattern.replace('\\', "/");
+        let glob =
+            Glob::new(&normalized).map_err(|error| DiscoveryConfigError::InvalidPattern {
+                kind,
+                pattern: pattern.clone(),
+                message: error.to_string(),
+            })?;
+        builder.add(glob);
+
+        // Globset's recursive prefix is intentionally supplemented so a pattern
+        // such as **/*.cls also matches a file directly at the matching root.
+        if let Some(root_pattern) = normalized.strip_prefix("**/") {
+            builder.add(Glob::new(root_pattern).map_err(|error| {
+                DiscoveryConfigError::InvalidPattern {
+                    kind,
+                    pattern: pattern.clone(),
+                    message: error.to_string(),
+                }
+            })?);
+        }
+    }
+    builder
+        .build()
+        .map_err(|error| DiscoveryConfigError::InvalidPattern {
+            kind,
+            pattern: "<combined patterns>".to_string(),
+            message: error.to_string(),
+        })
+}
+
+struct DiscoveryAccumulator<'a> {
+    base: &'a Path,
+    includes: GlobSet,
+    excludes: GlobSet,
+    identities: HashSet<PathBuf>,
+    files: Vec<PathBuf>,
+    errors: Vec<DiscoveryError>,
+}
+
+impl<'a> DiscoveryAccumulator<'a> {
+    fn new(base: &'a Path, includes: GlobSet, excludes: GlobSet) -> Self {
+        Self {
+            base,
+            includes,
+            excludes,
+            identities: HashSet::new(),
+            files: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    fn consider_file(&mut self, path: &Path, discovered: bool) {
+        let candidate = normalized_match_path(path, self.base);
+        if self.excludes.is_match(&candidate) || (discovered && !self.includes.is_match(&candidate))
+        {
+            return;
+        }
+
+        let identity = match fs::canonicalize(path) {
+            Ok(path) => path,
+            Err(error) => {
+                self.errors.push(DiscoveryError {
+                    path: path.to_path_buf(),
+                    message: format!("Failed to resolve file identity: {}", error),
+                });
+                return;
+            }
+        };
+        if self.identities.insert(identity) {
+            self.files.push(path.to_path_buf());
+        }
+    }
+}
+
+fn normalized_match_path(path: &Path, base: &Path) -> String {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .expect("current directory should be available during discovery")
+            .join(path)
+    };
+    let path = absolute.strip_prefix(base).unwrap_or(&absolute);
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn record_traversal_error(
+    errors: &mut Vec<DiscoveryError>,
+    fallback: &Path,
+    error: &walkdir::Error,
+) {
+    errors.push(DiscoveryError {
+        path: error.path().unwrap_or(fallback).to_path_buf(),
+        message: error.to_string(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{create_dir_all, write};
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempProject(PathBuf);
+
+    impl TempProject {
+        fn new() -> Self {
+            let suffix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("afmt-discovery-{suffix}"));
+            create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TempProject {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn project_files() -> (TempProject, FileSelectionConfig) {
+        let project = TempProject::new();
+        create_dir_all(project.0.join("nested")).unwrap();
+        create_dir_all(project.0.join(".git")).unwrap();
+        create_dir_all(project.0.join(".sfdx")).unwrap();
+        create_dir_all(project.0.join("node_modules")).unwrap();
+        write(project.0.join("root.cls"), "class Root {}\n").unwrap();
+        write(
+            project.0.join("nested/trigger.trigger"),
+            "trigger T on A (before insert) {}\n",
+        )
+        .unwrap();
+        write(project.0.join("nested/query.apex"), "System.debug('x');\n").unwrap();
+        write(project.0.join("nested/component.apexc"), "<apex:page/>\n").unwrap();
+        write(project.0.join("nested/ignored.txt"), "ignored\n").unwrap();
+        write(project.0.join(".git/ignored.cls"), "class Ignored {}\n").unwrap();
+        write(project.0.join(".sfdx/ignored.cls"), "class Ignored {}\n").unwrap();
+        write(
+            project.0.join("node_modules/ignored.cls"),
+            "class Ignored {}\n",
+        )
+        .unwrap();
+        (project, FileSelectionConfig::default())
+    }
+
+    #[test]
+    fn discovers_supported_root_and_nested_files_in_sorted_order() {
+        let (project, selection) = project_files();
+        let report =
+            discover_targets(std::slice::from_ref(&project.0), &selection, &project.0).unwrap();
+        let names = report
+            .files
+            .iter()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec![
+                project
+                    .0
+                    .join("nested/component.apexc")
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                project
+                    .0
+                    .join("nested/query.apex")
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                project
+                    .0
+                    .join("nested/trigger.trigger")
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                project
+                    .0
+                    .join("root.cls")
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+            ]
+        );
+    }
+
+    #[test]
+    fn exclusions_win_and_explicit_files_bypass_includes() {
+        let (project, _) = project_files();
+        let selection = FileSelectionConfig {
+            include: vec!["**/*.custom".to_string()],
+            exclude: vec!["**/nested/**".to_string()],
+        };
+        write(project.0.join("explicit.custom"), "class Explicit {}\n").unwrap();
+        write(
+            project.0.join("nested/excluded.custom"),
+            "class Excluded {}\n",
+        )
+        .unwrap();
+
+        let report = discover_targets(
+            &[
+                project.0.join("explicit.custom"),
+                project.0.join("nested"),
+                project.0.join("nested/excluded.custom"),
+            ],
+            &selection,
+            &project.0,
+        )
+        .unwrap();
+        assert_eq!(report.files, vec![project.0.join("explicit.custom")]);
+    }
+
+    #[test]
+    fn configured_include_can_select_custom_directory_extensions() {
+        let (project, _) = project_files();
+        let custom = project.0.join("nested/custom.custom");
+        write(&custom, "class Custom {}\n").unwrap();
+        let selection = FileSelectionConfig {
+            include: vec!["**/*.custom".to_string()],
+            exclude: Vec::new(),
+        };
+
+        let report =
+            discover_targets(std::slice::from_ref(&project.0), &selection, &project.0).unwrap();
+
+        assert_eq!(report.files, vec![custom]);
+    }
+
+    #[test]
+    fn discovery_preserves_operational_paths_while_matching_portably() {
+        let (project, selection) = project_files();
+        let report =
+            discover_targets(std::slice::from_ref(&project.0), &selection, &project.0).unwrap();
+
+        assert!(report.files.contains(&project.0.join("root.cls")));
+        assert_eq!(
+            normalized_match_path(&project.0.join("root.cls"), &project.0),
+            "root.cls"
+        );
+    }
+
+    #[test]
+    fn overlapping_inputs_are_deduplicated() {
+        let (project, selection) = project_files();
+        let file = project.0.join("root.cls");
+        let report = discover_targets(&[project.0.clone(), file], &selection, &project.0).unwrap();
+
+        assert_eq!(
+            report
+                .files
+                .iter()
+                .filter(|path| path.ends_with("root.cls"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn overlapping_directory_inputs_are_deduplicated() {
+        let (project, selection) = project_files();
+        let report = discover_targets(
+            &[project.0.clone(), project.0.join("nested")],
+            &selection,
+            &project.0,
+        )
+        .unwrap();
+
+        assert_eq!(report.files.len(), 4);
+    }
+
+    #[test]
+    fn invalid_globs_and_no_matches_fail_before_formatting() {
+        let project = TempProject::new();
+        let invalid = FileSelectionConfig {
+            include: vec!["[".to_string()],
+            exclude: Vec::new(),
+        };
+        assert!(matches!(
+            discover_targets(std::slice::from_ref(&project.0), &invalid, &project.0),
+            Err(DiscoveryConfigError::InvalidPattern {
+                kind: "include",
+                ..
+            })
+        ));
+
+        let invalid = FileSelectionConfig {
+            include: Vec::new(),
+            exclude: vec!["[".to_string()],
+        };
+        assert!(matches!(
+            discover_targets(std::slice::from_ref(&project.0), &invalid, &project.0),
+            Err(DiscoveryConfigError::InvalidPattern {
+                kind: "exclude",
+                ..
+            })
+        ));
+
+        let empty = FileSelectionConfig {
+            include: vec!["**/*.cls".to_string()],
+            exclude: Vec::new(),
+        };
+        assert_eq!(
+            discover_targets(std::slice::from_ref(&project.0), &empty, &project.0),
+            Err(DiscoveryConfigError::NoMatches)
+        );
+    }
+
+    #[test]
+    fn windows_separators_match_portable_patterns() {
+        let (project, _) = project_files();
+        let selection = FileSelectionConfig {
+            include: vec!["nested\\*.apex".to_string()],
+            exclude: Vec::new(),
+        };
+        let report =
+            discover_targets(std::slice::from_ref(&project.0), &selection, &project.0).unwrap();
+        assert_eq!(report.files.len(), 1);
+        assert!(report.files[0].ends_with("query.apex"));
+    }
+
+    #[test]
+    fn matching_uses_config_base_and_absolute_paths_outside_it() {
+        let (project, _) = project_files();
+        let base = project.0.join("nested");
+
+        assert_eq!(
+            normalized_match_path(&base.join("query.apex"), &base),
+            "query.apex"
+        );
+        let outside = normalized_match_path(&project.0.join("root.cls"), &base);
+        assert!(outside.ends_with("/root.cls") || outside.ends_with("\\root.cls"));
+    }
+
+    #[test]
+    fn nonexistent_inputs_are_distinguished_from_empty_matches() {
+        let project = TempProject::new();
+        let missing = project.0.join("missing.cls");
+
+        assert_eq!(
+            discover_targets(
+                std::slice::from_ref(&missing),
+                &FileSelectionConfig::default(),
+                &project.0
+            ),
+            Err(DiscoveryConfigError::InputMissing(missing))
+        );
+
+        let invalid = PathBuf::from("invalid\0path");
+        assert!(matches!(
+            discover_targets(
+                std::slice::from_ref(&invalid),
+                &FileSelectionConfig::default(),
+                &project.0
+            ),
+            Err(DiscoveryConfigError::InputError { path, .. }) if path == invalid
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_directories_are_not_traversed_and_unsupported_inputs_are_rejected() {
+        let (project, selection) = project_files();
+        let linked = project.0.join("linked");
+        symlink(project.0.join("nested"), &linked).unwrap();
+        let report =
+            discover_targets(std::slice::from_ref(&project.0), &selection, &project.0).unwrap();
+        assert!(!report.files.iter().any(|path| path.starts_with(&linked)));
+
+        let link_file = project.0.join("link-file.cls");
+        symlink(project.0.join("root.cls"), &link_file).unwrap();
+        assert_eq!(
+            discover_targets(std::slice::from_ref(&link_file), &selection, &project.0),
+            Err(DiscoveryConfigError::InputUnsupported(link_file))
+        );
+    }
+
+    #[test]
+    fn traversal_errors_retain_their_path_and_message() {
+        let project = TempProject::new();
+        let missing = project.0.join("walk-missing");
+        let error = WalkDir::new(&missing)
+            .follow_links(false)
+            .into_iter()
+            .next()
+            .expect("walk should yield an error")
+            .expect_err("missing walk root should fail");
+        let mut errors = Vec::new();
+
+        record_traversal_error(&mut errors, &project.0, &error);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].path, missing);
+        assert!(!errors[0].message.is_empty());
+    }
+}

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -60,6 +60,7 @@ pub struct PrettyConfig {
     pub brace_style: BraceStyle,
     pub wrap_single_statements: bool,
     pub indent_style: IndentStyle,
+    pub normalize_annotation_casing: bool,
 }
 
 impl PrettyConfig {
@@ -68,6 +69,7 @@ impl PrettyConfig {
         brace_style: BraceStyle,
         wrap_single_statements: bool,
         indent_style: IndentStyle,
+        normalize_annotation_casing: bool,
     ) -> Self {
         if indent_size == 0 {
             panic!("indent_size must be greater than 0")
@@ -77,6 +79,7 @@ impl PrettyConfig {
                 brace_style,
                 wrap_single_statements,
                 indent_style,
+                normalize_annotation_casing,
             }
         }
     }

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -1,7 +1,7 @@
 pub type DocRef<'a> = &'a Doc<'a>;
 
-pub fn pretty_print(doc_ref: DocRef, max_width: u32) -> String {
-    let mut printer = PrettyPrinter::new(doc_ref, max_width);
+pub fn pretty_print(doc_ref: DocRef, max_width: u32, config: PrettyConfig) -> String {
+    let mut printer = PrettyPrinter::new(doc_ref, max_width, config);
     printer.print()
 }
 
@@ -23,20 +23,61 @@ pub enum Doc<'a> {
 
 struct PrettyPrinter<'a> {
     max_width: u32,
+    indent_size: u32,
+    indent_style: IndentStyle,
     col: u32,
     chunks: Vec<Chunk<'a>>,
 }
 
+/// Placement of an opening brace relative to the construct that owns it.
+///
+/// This is the only axis that distinguishes K&R from Allman output: the brace's
+/// own internal layout (open, indented body, close on its own line) is shared by
+/// both styles. See `DocBuilder::body_open_sep`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BraceStyle {
+    /// Opening brace stays on the same line as the header: `class Foo {`.
+    #[default]
+    KAndR,
+    /// Opening brace drops to its own line at the header's indent:
+    /// `class Foo\n{`.
+    Allman,
+}
+
+/// Indentation character used when materializing pending newlines.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndentStyle {
+    #[default]
+    Space,
+    Tab,
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct PrettyConfig {
     pub indent_size: u32,
+    pub brace_style: BraceStyle,
+    pub wrap_single_statements: bool,
+    pub indent_style: IndentStyle,
 }
 
 impl PrettyConfig {
-    pub fn new(indent_size: u32) -> Self {
+    pub fn new(
+        indent_size: u32,
+        brace_style: BraceStyle,
+        wrap_single_statements: bool,
+        indent_style: IndentStyle,
+    ) -> Self {
         if indent_size == 0 {
             panic!("indent_size must be greater than 0")
         } else {
-            Self { indent_size }
+            Self {
+                indent_size,
+                brace_style,
+                wrap_single_statements,
+                indent_style,
+            }
         }
     }
 }
@@ -80,7 +121,7 @@ impl<'a> Chunk<'a> {
 }
 
 impl<'a> PrettyPrinter<'a> {
-    fn new(doc_ref: DocRef<'a>, max_width: u32) -> Self {
+    fn new(doc_ref: DocRef<'a>, max_width: u32, config: PrettyConfig) -> Self {
         let chunk = Chunk {
             doc_ref,
             indent: 0,
@@ -89,6 +130,8 @@ impl<'a> PrettyPrinter<'a> {
 
         Self {
             max_width,
+            indent_size: config.indent_size,
+            indent_style: config.indent_style,
             col: 0,
             chunks: vec![chunk],
         }
@@ -186,10 +229,20 @@ impl<'a> PrettyPrinter<'a> {
 
     fn insert_newline_with_indent(&mut self, result: &mut String, indent: u32) {
         result.push('\n');
-        for _ in 0..indent {
-            result.push(' ');
+        match self.indent_style {
+            IndentStyle::Space => {
+                for _ in 0..indent {
+                    result.push(' ');
+                }
+                self.col = indent;
+            }
+            IndentStyle::Tab => {
+                for _ in 0..indent / self.indent_size {
+                    result.push('\t');
+                }
+                self.col = indent / self.indent_size;
+            }
         }
-        self.col = indent;
     }
 
     //fn insert_newline_with_indent(&mut self, result: &mut String, chunk: &Chunk) {

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -54,12 +54,24 @@ pub enum IndentStyle {
     Tab,
 }
 
+/// Placement of the leading star in JavaDoc continuation lines.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JavadocStarColumn {
+    /// Preserve afmt's existing ` *` continuation-line style.
+    #[default]
+    Offset,
+    /// Align continuation-line stars with the comment's indentation column.
+    Flush,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct PrettyConfig {
     pub indent_size: u32,
     pub brace_style: BraceStyle,
     pub wrap_single_statements: bool,
     pub indent_style: IndentStyle,
+    pub javadoc_star_column: JavadocStarColumn,
 }
 
 impl PrettyConfig {
@@ -68,6 +80,7 @@ impl PrettyConfig {
         brace_style: BraceStyle,
         wrap_single_statements: bool,
         indent_style: IndentStyle,
+        javadoc_star_column: JavadocStarColumn,
     ) -> Self {
         if indent_size == 0 {
             panic!("indent_size must be greater than 0")
@@ -77,6 +90,7 @@ impl PrettyConfig {
                 brace_style,
                 wrap_single_statements,
                 indent_style,
+                javadoc_star_column,
             }
         }
     }

--- a/src/doc_builder.rs
+++ b/src/doc_builder.rs
@@ -7,7 +7,7 @@ use typed_arena::Arena;
 
 pub struct DocBuilder<'a> {
     arena: Arena<Doc<'a>>,
-    config: PrettyConfig,
+    pub(crate) config: PrettyConfig,
 }
 
 impl<'a> DocBuilder<'a> {

--- a/src/doc_builder.rs
+++ b/src/doc_builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     data_model::DocBuild,
-    doc::{Doc, DocRef, PrettyConfig},
+    doc::{BraceStyle, Doc, DocRef, PrettyConfig},
     enum_def::BodyMember,
 };
 use typed_arena::Arena;
@@ -220,6 +220,84 @@ impl<'a> DocBuilder<'a> {
     pub fn indent(&'a self, doc_ref: DocRef<'a>) -> DocRef<'a> {
         let relative_indent = self.config.indent_size;
         self.arena.alloc(Doc::Indent(relative_indent, doc_ref))
+    }
+
+    /// Separator emitted between a construct's header and its opening brace.
+    ///
+    /// This is the sole difference between K&R and Allman: a space keeps the
+    /// brace on the header line; a newline drops it to its own line at the
+    /// header's indent. Callers that currently push `b.txt(" ")` before a body
+    /// block should push this instead. Must not be placed inside a `group(...)`
+    /// (newlines don't compose with groups).
+    pub fn body_open_sep(&'a self) -> DocRef<'a> {
+        match self.config.brace_style {
+            BraceStyle::KAndR => self.txt(" "),
+            BraceStyle::Allman => self.nl(),
+        }
+    }
+
+    /// Separator between adjacent clauses such as `try`/`catch`/`finally`.
+    pub fn clause_sep(&'a self) -> DocRef<'a> {
+        self.body_open_sep()
+    }
+
+    /// Whether single-statement clause bodies are wrapped in synthesized braces.
+    pub fn wraps_single(&self) -> bool {
+        self.config.wrap_single_statements
+    }
+
+    /// Brace-wrap an already-built single (non-block) statement: separator +
+    /// `{` + indented statement + `}` on its own line. Honors `brace_style` via
+    /// `body_open_sep`.
+    fn wrap_single(&'a self, body: DocRef<'a>) -> DocRef<'a> {
+        self.concat(vec![
+            self.body_open_sep(),
+            self.txt("{"),
+            self.indent(self.nl()),
+            self.indent(body),
+            self.nl(),
+            self.txt("}"),
+        ])
+    }
+
+    /// Emit an empty brace block when single-statement bodies are enabled.
+    pub fn empty_clause_body(&'a self) -> DocRef<'a> {
+        if self.config.wrap_single_statements {
+            self.concat(vec![
+                self.body_open_sep(),
+                self.txt("{"),
+                self.nl(),
+                self.txt("}"),
+            ])
+        } else {
+            self.nil()
+        }
+    }
+
+    /// Emit a control-flow clause body (an `if`/`else`/loop body) with brace
+    /// placement and single-statement wrapping driven by config.
+    ///
+    /// - Block body: `body_open_sep` + the block (already brace-wrapped).
+    /// - Single statement + `wrap_single_statements`: synthesize a brace block.
+    /// - Single statement otherwise: the legacy brace-less form. `break_single`
+    ///   selects the fallback layout that must be preserved per construct:
+    ///   `true` puts the statement on its own indented line (`if` style),
+    ///   `false` keeps it inline after a space (loop style).
+    pub fn clause_body(
+        &'a self,
+        body: DocRef<'a>,
+        is_block: bool,
+        break_single: bool,
+    ) -> DocRef<'a> {
+        if is_block {
+            self.concat(vec![self.body_open_sep(), body])
+        } else if self.config.wrap_single_statements {
+            self.wrap_single(body)
+        } else if break_single {
+            self.concat(vec![self.indent(self.nl()), self.indent(body)])
+        } else {
+            self.concat(vec![self.txt(" "), body])
+        }
     }
 
     pub fn dedent(&'a self, doc_ref: DocRef<'a>) -> DocRef<'a> {

--- a/src/doc_builder.rs
+++ b/src/doc_builder.rs
@@ -246,6 +246,11 @@ impl<'a> DocBuilder<'a> {
         self.config.wrap_single_statements
     }
 
+    /// Whether known Apex annotation names should use canonical casing.
+    pub fn normalizes_annotation_casing(&self) -> bool {
+        self.config.normalize_annotation_casing
+    }
+
     /// Brace-wrap an already-built single (non-block) statement: separator +
     /// `{` + indented statement + `}` on its own line. Honors `brace_style` via
     /// `body_open_sep`.

--- a/src/enum_def.rs
+++ b/src/enum_def.rs
@@ -314,6 +314,7 @@ impl<'a> DocBuild<'a> for Expression {
 //  ),
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum PrimaryExpression {
     Literal(Literal_),
     Identifier(ValueNode),
@@ -1461,7 +1462,7 @@ impl DateLiteralWithParam {
 impl<'a> DocBuild<'a> for DateLiteralWithParam {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b.txt(format!("{}:{}", &self.date_literal, &self.param)));
+            result.push(b.txt(format!("{}:{}", self.date_literal, self.param)));
         });
     }
 }
@@ -1563,6 +1564,7 @@ impl<'a> DocBuild<'a> for OffsetClause {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum FunctionExpressionVariant {
     WithGEO {
         function_name: ValueNode,

--- a/src/enum_def.rs
+++ b/src/enum_def.rs
@@ -314,6 +314,8 @@ impl<'a> DocBuild<'a> for Expression {
 //  ),
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum PrimaryExpression {
     Literal(Literal_),
     Identifier(ValueNode),
@@ -1461,7 +1463,7 @@ impl DateLiteralWithParam {
 impl<'a> DocBuild<'a> for DateLiteralWithParam {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
         build_with_comments_and_punc(b, &self.node_context, result, |b, result| {
-            result.push(b.txt(format!("{}:{}", &self.date_literal, &self.param)));
+            result.push(b.txt(format!("{}:{}", self.date_literal, self.param)));
         });
     }
 }
@@ -1563,6 +1565,8 @@ impl<'a> DocBuild<'a> for OffsetClause {
 }
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum FunctionExpressionVariant {
     WithGEO {
         function_name: ValueNode,

--- a/src/enum_def.rs
+++ b/src/enum_def.rs
@@ -14,6 +14,8 @@ pub enum RootMember {
     Enum(Box<EnumDeclaration>),
     Interface(Box<InterfaceDeclaration>),
     Trigger(Box<TriggerDeclaration>),
+    // Anonymous Apex (`.apex`) files allow bare statements at the top level.
+    Stmt(Box<Statement>),
 }
 
 impl RootMember {
@@ -23,7 +25,8 @@ impl RootMember {
             "enum_declaration" => Self::Enum(Box::new(EnumDeclaration::new(n))),
             "trigger_declaration" => Self::Trigger(Box::new(TriggerDeclaration::new(n))),
             "interface_declaration" => Self::Interface(Box::new(InterfaceDeclaration::new(n))),
-            _ => panic_unknown_node(n, "Root"),
+            // Fall back to statement handling for anonymous Apex top-level code.
+            _ => Self::Stmt(Box::new(Statement::new(n))),
         }
     }
 }
@@ -41,6 +44,9 @@ impl<'a> DocBuild<'a> for RootMember {
                 result.push(n.build(b));
             }
             RootMember::Trigger(n) => {
+                result.push(n.build(b));
+            }
+            RootMember::Stmt(n) => {
                 result.push(n.build(b));
             }
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -245,3 +245,158 @@ impl Formatter {
         last_error_node // Return the last (deepest) error node
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, Formatter};
+    use crate::doc::{BraceStyle, IndentStyle};
+
+    #[test]
+    fn style_keys_default_when_omitted() {
+        let config: Config = toml::from_str("max_width = 80\n").unwrap();
+
+        assert_eq!(config.brace_style, BraceStyle::KAndR);
+        assert_eq!(config.indent_style, IndentStyle::Space);
+        assert!(!config.wrap_single_statements);
+    }
+
+    #[test]
+    fn style_keys_parse_from_snake_case() {
+        let config: Config = toml::from_str(
+            "brace_style = \"allman\"\nindent_style = \"tab\"\nwrap_single_statements = true\n",
+        )
+        .unwrap();
+
+        assert_eq!(config.brace_style, BraceStyle::Allman);
+        assert_eq!(config.indent_style, IndentStyle::Tab);
+        assert!(config.wrap_single_statements);
+    }
+
+    #[test]
+    fn invalid_brace_style_is_an_error() {
+        let result: Result<Config, _> = toml::from_str("brace_style = \"stroustrup\"\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_indent_style_is_an_error() {
+        let result: Result<Config, _> = toml::from_str("indent_style = \"spaces\"\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allman_moves_container_and_control_braces_to_their_own_line() {
+        let source = "class T {\n  void m() {\n    if (a) { x(); }\n  }\n}\n";
+        let config = Config {
+            brace_style: BraceStyle::Allman,
+            ..Config::default()
+        };
+
+        let out = Formatter::format_one(source, config);
+
+        assert_eq!(
+            out,
+            "class T\n{\n  void m()\n  {\n    if (a)\n    {\n      x();\n    }\n  }\n}\n"
+        );
+    }
+
+    #[test]
+    fn wrap_single_statements_adds_braces_to_bare_clause_bodies() {
+        let source = "class T {\n  void m() {\n    if (a) x(); else y();\n    for (Account acc : accts) z();\n  }\n}\n";
+        let config = Config {
+            wrap_single_statements: true,
+            ..Config::default()
+        };
+
+        let out = Formatter::format_one(source, config);
+
+        // Bare `if`/`else` and loop bodies each gain a brace block; else-if stays
+        // inline (none here). K&R placement is preserved (default brace_style).
+        assert!(out.contains("if (a) {\n      x();\n    } else {\n      y();\n    }"));
+        assert!(out.contains("for (Account acc : accts) {\n      z();\n    }"));
+    }
+
+    #[test]
+    fn tab_indentation_is_independent_of_brace_style_and_wrapping() {
+        let source = "class T {\n  void m() {\n    if (a) x();\n  }\n}\n";
+        let config = Config {
+            indent_style: IndentStyle::Tab,
+            ..Config::default()
+        };
+
+        let out = Formatter::format_one(source, config);
+
+        assert_eq!(
+            out,
+            "class T {\n\tvoid m() {\n\t\tif (a)\n\t\t\tx();\n\t}\n}\n"
+        );
+    }
+
+    #[test]
+    fn allman_applies_to_properties_and_accessor_bodies() {
+        let source = "public class Me {\n  public integer prop {\n    get {\n      return prop;\n    }\n    set {\n      prop = value;\n    }\n  }\n}\n";
+        let config = Config {
+            brace_style: BraceStyle::Allman,
+            ..Config::default()
+        };
+
+        let out = Formatter::format_one(source, config);
+
+        assert!(out.contains("public integer prop\n  {"));
+        assert!(out.contains("get\n    {"));
+        assert!(out.contains("set\n    {"));
+    }
+
+    #[test]
+    fn wrapped_single_statements_include_empty_loop_bodies() {
+        let source = "class T {\n  void m() {\n    for (Integer i = 0; i < 1; i++);\n    for (Account acc : accts);\n    while (true);\n  }\n}\n";
+        let config = Config {
+            wrap_single_statements: true,
+            ..Config::default()
+        };
+
+        let out = Formatter::format_one(source, config);
+
+        assert_eq!(out.matches("{\n    }").count(), 3);
+    }
+
+    #[test]
+    fn wrapped_empty_while_preserves_terminator_comments() {
+        let source = "class T {\n  void m() {\n    while (true) /* while empty */ ;\n  }\n}\n";
+        let config = Config {
+            wrap_single_statements: true,
+            ..Config::default()
+        };
+
+        let out = Formatter::format_one(source, config);
+
+        assert!(out.contains("/* while empty */"));
+        assert!(out.contains("while (true) /* while empty */"));
+    }
+
+    #[test]
+    fn allman_places_catch_and_finally_on_new_lines() {
+        let source = "class T {\n  void m() {\n    try {\n      work();\n    } catch (Exception e) {\n      recover();\n    } finally {\n      finish();\n    }\n  }\n}\n";
+        let config = Config {
+            brace_style: BraceStyle::Allman,
+            ..Config::default()
+        };
+
+        let out = Formatter::format_one(source, config);
+
+        assert!(out.contains("    }\n    catch (Exception e)\n    {"));
+        assert!(out.contains("    }\n    finally\n    {"));
+    }
+
+    #[test]
+    fn default_config_keeps_k_and_r_and_bare_bodies() {
+        let source = "class T {\n  void m() {\n    if (a) x();\n  }\n}\n";
+
+        let out = Formatter::format_one(source, Config::default());
+
+        assert_eq!(
+            out,
+            "class T {\n  void m() {\n    if (a)\n      x();\n  }\n}\n"
+        );
+    }
+}

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -35,6 +35,11 @@ pub struct Config {
     /// Indentation character. Default `space`.
     #[serde(default)]
     pub indent_style: IndentStyle,
+
+    /// Normalize known Apex annotation names to Salesforce's canonical casing.
+    /// Default `false` preserves source casing.
+    #[serde(default)]
+    pub normalize_annotation_casing: bool,
 }
 
 fn default_max_width() -> u32 {
@@ -53,6 +58,7 @@ impl Default for Config {
             brace_style: BraceStyle::default(),
             wrap_single_statements: false,
             indent_style: IndentStyle::default(),
+            normalize_annotation_casing: false,
         }
     }
 }
@@ -65,6 +71,7 @@ impl Config {
             brace_style: BraceStyle::default(),
             wrap_single_statements: false,
             indent_style: IndentStyle::default(),
+            normalize_annotation_casing: false,
         }
     }
 
@@ -174,6 +181,7 @@ impl Formatter {
             config.brace_style,
             config.wrap_single_statements,
             config.indent_style,
+            config.normalize_annotation_casing,
         );
         let b = DocBuilder::new(c);
         let doc_ref = root.build(&b);
@@ -258,18 +266,20 @@ mod tests {
         assert_eq!(config.brace_style, BraceStyle::KAndR);
         assert_eq!(config.indent_style, IndentStyle::Space);
         assert!(!config.wrap_single_statements);
+        assert!(!config.normalize_annotation_casing);
     }
 
     #[test]
     fn style_keys_parse_from_snake_case() {
         let config: Config = toml::from_str(
-            "brace_style = \"allman\"\nindent_style = \"tab\"\nwrap_single_statements = true\n",
+            "brace_style = \"allman\"\nindent_style = \"tab\"\nwrap_single_statements = true\nnormalize_annotation_casing = true\n",
         )
         .unwrap();
 
         assert_eq!(config.brace_style, BraceStyle::Allman);
         assert_eq!(config.indent_style, IndentStyle::Tab);
         assert!(config.wrap_single_statements);
+        assert!(config.normalize_annotation_casing);
     }
 
     #[test]
@@ -282,6 +292,109 @@ mod tests {
     fn invalid_indent_style_is_an_error() {
         let result: Result<Config, _> = toml::from_str("indent_style = \"spaces\"\n");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_annotation_casing_value_is_an_error() {
+        let result: Result<Config, _> = toml::from_str("normalize_annotation_casing = \"true\"\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn annotation_casing_normalizes_known_names_and_preserves_unknown_names() {
+        let source = "@iStEsT(SeeAllData=true)\n@MyCustomAnno\nclass T {\n  // Keep this adjacent comment.\n  @aUrAeNaBlEd\n  static void run() {}\n}\n";
+        let config = Config {
+            normalize_annotation_casing: true,
+            ..Config::default()
+        };
+
+        let output = Formatter::format_one(source, config);
+
+        assert!(output.contains("@IsTest(SeeAllData=true)"));
+        assert!(output.contains("@MyCustomAnno"));
+        assert!(output.contains("// Keep this adjacent comment."));
+        assert!(output.contains("@AuraEnabled"));
+    }
+
+    #[test]
+    fn annotation_casing_covers_every_known_name() {
+        let cases = [
+            ("iStEsT", "IsTest"),
+            ("tEsTsEtUp", "TestSetup"),
+            ("tEsTvIsIbLe", "TestVisible"),
+            ("aUrAeNaBlEd", "AuraEnabled"),
+            ("fUtUrE", "Future"),
+            ("iNvOcAbLeMeThOd", "InvocableMethod"),
+            ("iNvOcAbLeVaRiAbLe", "InvocableVariable"),
+            ("hTtPgEt", "HttpGet"),
+            ("hTtPpOsT", "HttpPost"),
+            ("hTtPpUt", "HttpPut"),
+            ("hTtPpAtCh", "HttpPatch"),
+            ("hTtPdElEtE", "HttpDelete"),
+            ("rEsTrEsOuRcE", "RestResource"),
+            ("rEaDoNlY", "ReadOnly"),
+            ("rEmOtEaCtIoN", "RemoteAction"),
+            ("dEpReCaTeD", "Deprecated"),
+            ("sUpPrEsSwArNiNgS", "SuppressWarnings"),
+            ("nAmEsPaCeAcCeSsIbLe", "NamespaceAccessible"),
+            ("jSoNaCcEsS", "JsonAccess"),
+        ];
+        let mut source = cases
+            .iter()
+            .map(|(input, _)| format!("@{}\n", input))
+            .collect::<String>();
+        source.push_str("@mYCustomAnno\nclass T {}\n");
+        let config = Config {
+            normalize_annotation_casing: true,
+            ..Config::default()
+        };
+
+        let output = Formatter::format_one(&source, config);
+
+        for (_, expected) in cases {
+            assert!(
+                output.lines().any(|line| line == format!("@{}", expected)),
+                "missing canonical annotation @{expected} in output:\n{output}"
+            );
+        }
+        assert!(output.lines().any(|line| line == "@mYCustomAnno"));
+    }
+
+    #[test]
+    fn annotation_name_comments_survive_casing() {
+        let source = "@/* Keep this name comment. */iStEsT\nclass T {}\n";
+        let config = Config {
+            normalize_annotation_casing: true,
+            ..Config::default()
+        };
+
+        let output = Formatter::format_one(source, config);
+
+        assert!(
+            output.contains("@/* Keep this name comment. */ IsTest"),
+            "unexpected output:\n{output}"
+        );
+    }
+
+    #[test]
+    fn annotation_casing_is_idempotent() {
+        let source = "@ISTEST\nclass T {}\n";
+        let config = Config {
+            normalize_annotation_casing: true,
+            ..Config::default()
+        };
+
+        let once_config = config.clone();
+        let once = std::thread::spawn(move || Formatter::format_one(source, once_config))
+            .join()
+            .unwrap();
+        let once_for_second_pass = once.clone();
+        let twice =
+            std::thread::spawn(move || Formatter::format_one(&once_for_second_pass, config))
+                .join()
+                .unwrap();
+
+        assert_eq!(once, twice);
     }
 
     #[test]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,6 +1,6 @@
 use crate::context::CommentMap;
 use crate::data_model::*;
-use crate::doc::{pretty_print, PrettyConfig};
+use crate::doc::{pretty_print, BraceStyle, IndentStyle, PrettyConfig};
 use crate::doc_builder::DocBuilder;
 use crate::message_helper::{red, yellow};
 use crate::utility::{
@@ -23,6 +23,18 @@ pub struct Config {
 
     #[serde(default = "default_indent_size")]
     pub indent_size: u32,
+
+    /// Opening-brace placement. Default `k_and_r` preserves current output.
+    #[serde(default)]
+    pub brace_style: BraceStyle,
+
+    /// Wrap single-statement `if`/`else`/loop bodies in braces. Default `false`.
+    #[serde(default)]
+    pub wrap_single_statements: bool,
+
+    /// Indentation character. Default `space`.
+    #[serde(default)]
+    pub indent_style: IndentStyle,
 }
 
 fn default_max_width() -> u32 {
@@ -38,6 +50,9 @@ impl Default for Config {
         Self {
             max_width: default_max_width(),
             indent_size: default_indent_size(),
+            brace_style: BraceStyle::default(),
+            wrap_single_statements: false,
+            indent_style: IndentStyle::default(),
         }
     }
 }
@@ -47,6 +62,9 @@ impl Config {
         Self {
             max_width,
             indent_size: 2,
+            brace_style: BraceStyle::default(),
+            wrap_single_statements: false,
+            indent_style: IndentStyle::default(),
         }
     }
 
@@ -151,11 +169,16 @@ impl Formatter {
         let root: Root = enrich(&ast_tree);
 
         // traverse enriched data and create pretty print combinators
-        let c = PrettyConfig::new(config.indent_size);
+        let c = PrettyConfig::new(
+            config.indent_size,
+            config.brace_style,
+            config.wrap_single_statements,
+            config.indent_style,
+        );
         let b = DocBuilder::new(c);
         let doc_ref = root.build(&b);
 
-        let result = pretty_print(doc_ref, config.max_width);
+        let result = pretty_print(doc_ref, config.max_width, c);
 
         // debugging tool: use this to print named node value + comments in bucket
         // print_comment_map(&ast_tree);

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,6 +1,6 @@
 use crate::context::CommentMap;
 use crate::data_model::*;
-use crate::doc::{pretty_print, BraceStyle, IndentStyle, PrettyConfig};
+use crate::doc::{pretty_print, PrettyConfig};
 use crate::doc_builder::DocBuilder;
 use crate::message_helper::{red, yellow};
 use crate::utility::{
@@ -12,6 +12,8 @@ use std::sync::mpsc;
 use std::thread;
 use std::{fs, path::Path};
 use tree_sitter::{Node, Parser, Tree};
+
+pub use crate::doc::{BraceStyle, IndentStyle, JavadocStarColumn};
 
 #[allow(unused_imports)]
 use crate::utility::print_comment_map;
@@ -35,6 +37,10 @@ pub struct Config {
     /// Indentation character. Default `space`.
     #[serde(default)]
     pub indent_style: IndentStyle,
+
+    /// JavaDoc continuation-star placement. Default `offset` preserves output.
+    #[serde(default)]
+    pub javadoc_star_column: JavadocStarColumn,
 }
 
 fn default_max_width() -> u32 {
@@ -53,6 +59,7 @@ impl Default for Config {
             brace_style: BraceStyle::default(),
             wrap_single_statements: false,
             indent_style: IndentStyle::default(),
+            javadoc_star_column: JavadocStarColumn::default(),
         }
     }
 }
@@ -65,6 +72,7 @@ impl Config {
             brace_style: BraceStyle::default(),
             wrap_single_statements: false,
             indent_style: IndentStyle::default(),
+            javadoc_star_column: JavadocStarColumn::default(),
         }
     }
 
@@ -174,6 +182,7 @@ impl Formatter {
             config.brace_style,
             config.wrap_single_statements,
             config.indent_style,
+            config.javadoc_star_column,
         );
         let b = DocBuilder::new(c);
         let doc_ref = root.build(&b);
@@ -249,7 +258,7 @@ impl Formatter {
 #[cfg(test)]
 mod tests {
     use super::{Config, Formatter};
-    use crate::doc::{BraceStyle, IndentStyle};
+    use crate::doc::{BraceStyle, IndentStyle, JavadocStarColumn};
 
     #[test]
     fn style_keys_default_when_omitted() {
@@ -257,18 +266,20 @@ mod tests {
 
         assert_eq!(config.brace_style, BraceStyle::KAndR);
         assert_eq!(config.indent_style, IndentStyle::Space);
+        assert_eq!(config.javadoc_star_column, JavadocStarColumn::Offset);
         assert!(!config.wrap_single_statements);
     }
 
     #[test]
     fn style_keys_parse_from_snake_case() {
         let config: Config = toml::from_str(
-            "brace_style = \"allman\"\nindent_style = \"tab\"\nwrap_single_statements = true\n",
+            "brace_style = \"allman\"\nindent_style = \"tab\"\nwrap_single_statements = true\njavadoc_star_column = \"flush\"\n",
         )
         .unwrap();
 
         assert_eq!(config.brace_style, BraceStyle::Allman);
         assert_eq!(config.indent_style, IndentStyle::Tab);
+        assert_eq!(config.javadoc_star_column, JavadocStarColumn::Flush);
         assert!(config.wrap_single_statements);
     }
 
@@ -282,6 +293,43 @@ mod tests {
     fn invalid_indent_style_is_an_error() {
         let result: Result<Config, _> = toml::from_str("indent_style = \"spaces\"\n");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_javadoc_star_column_is_an_error() {
+        let result: Result<Config, _> = toml::from_str("javadoc_star_column = \"aligned\"\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn flush_javadoc_stars_are_indented_and_idempotent() {
+        let source = "class T {\n  /**\n   * @param value the input\n   *\n   * @return the result\n   */\n  Integer m(Integer value) { /* keep */ return value; }\n}\n";
+        let config = Config {
+            brace_style: BraceStyle::Allman,
+            indent_style: IndentStyle::Tab,
+            javadoc_star_column: JavadocStarColumn::Flush,
+            ..Config::default()
+        };
+
+        let first = std::thread::spawn({
+            let source = source.to_owned();
+            let config = config.clone();
+            move || Formatter::format_one(&source, config)
+        })
+        .join()
+        .unwrap();
+
+        assert!(
+            first.contains("\t/**\n\t* @param value the input\n\t*\n\t* @return the result\n\t*/")
+        );
+        assert!(first.contains("/* keep */"));
+        let second = std::thread::spawn({
+            let source = first.clone();
+            move || Formatter::format_one(&source, config)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(second, first);
     }
 
     #[test]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -4,13 +4,17 @@ use crate::doc::{pretty_print, PrettyConfig};
 use crate::doc_builder::DocBuilder;
 use crate::message_helper::{red, yellow};
 use crate::utility::{
-    assert_no_missing_comments, collect_comments, enrich, set_thread_comment_map,
-    set_thread_source_code, truncate_snippet,
+    assert_no_missing_comments, clear_thread_comment_map, clear_thread_source_code,
+    collect_comments, enrich, set_thread_comment_map, set_thread_source_code, truncate_snippet,
 };
+use rayon::prelude::*;
 use serde::Deserialize;
-use std::sync::mpsc;
-use std::thread;
-use std::{fs, path::Path};
+use std::{
+    fs,
+    panic::{catch_unwind, AssertUnwindSafe},
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
 use tree_sitter::{Node, Parser, Tree};
 
 #[allow(unused_imports)]
@@ -67,15 +71,56 @@ impl Config {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FormattedFile {
+    pub content: String,
+    pub changed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FormatFileError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl std::fmt::Display for FormatFileError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.path.display(), self.message)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FormatOutcome {
+    pub path: PathBuf,
+    pub elapsed: Duration,
+    pub result: Result<FormattedFile, FormatFileError>,
+}
+
+struct ThreadStateGuard;
+
+impl Drop for ThreadStateGuard {
+    fn drop(&mut self) {
+        clear_thread_source_code();
+        clear_thread_comment_map();
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Formatter {
     config: Config,
-    source_files: Vec<String>,
+    source_files: Vec<PathBuf>,
     //pub errors: ReportedErrors,
 }
 
 impl Formatter {
     pub fn new(config: Config, source_files: Vec<String>) -> Self {
+        Self::new_from_paths(
+            config,
+            source_files.into_iter().map(PathBuf::from).collect(),
+        )
+    }
+
+    pub fn new_from_paths(config: Config, source_files: Vec<PathBuf>) -> Self {
         Self {
             config,
             source_files,
@@ -100,46 +145,79 @@ impl Formatter {
     }
 
     pub fn format(&self) -> Vec<Result<String, String>> {
-        let (tx, rx) = mpsc::channel();
-        let config = self.config.clone();
+        self.format_with_outcomes()
+            .into_iter()
+            .map(|outcome| {
+                outcome
+                    .result
+                    .map(|formatted| formatted.content)
+                    .map_err(|error| error.to_string())
+            })
+            .collect()
+    }
 
-        for file in &self.source_files {
-            let tx = tx.clone();
-            let config = config.clone();
-            let file = file.clone();
+    pub fn format_with_outcomes(&self) -> Vec<FormatOutcome> {
+        let config = &self.config;
 
-            thread::spawn(move || {
-                let result = std::panic::catch_unwind(|| {
-                    let source_code = fs::read_to_string(Path::new(&file))
-                        .map_err(|e| {
-                            format!(
-                                "Failed to read file: {} {}",
-                                red(&file),
-                                yellow(e.to_string().as_str())
-                            )
-                        })
-                        .unwrap();
+        self.source_files
+            .par_iter()
+            .map(|file| {
+                let path = file.clone();
+                let started = Instant::now();
+                let result = Self::try_format_one(&path, config.clone());
 
-                    Formatter::format_one(&source_code, config)
-                });
-                match result {
-                    Ok(result) => {
-                        tx.send(Ok(result)).expect("failed to send result in tx");
-                    }
-                    Err(_) => tx
-                        .send(Err("Thread panicked".to_string()))
-                        .expect("failed to send error in tx"),
+                FormatOutcome {
+                    path,
+                    elapsed: started.elapsed(),
+                    result,
                 }
-            });
-        }
+            })
+            .collect()
+    }
 
-        drop(tx);
+    pub fn try_format_one(path: &Path, config: Config) -> Result<FormattedFile, FormatFileError> {
+        let source_code = fs::read_to_string(path).map_err(|error| FormatFileError {
+            path: path.to_path_buf(),
+            message: format!(
+                "Failed to read file: {}",
+                yellow(error.to_string().as_str())
+            ),
+        })?;
 
-        rx.into_iter().collect()
+        let formatted = match catch_unwind(AssertUnwindSafe(|| {
+            Self::try_format_source(&source_code, config)
+        })) {
+            Ok(Ok(formatted)) => formatted,
+            Ok(Err(message)) => {
+                return Err(FormatFileError {
+                    path: path.to_path_buf(),
+                    message,
+                });
+            }
+            Err(panic_payload) => {
+                return Err(FormatFileError {
+                    path: path.to_path_buf(),
+                    message: format!("Formatting panicked: {}", panic_message(panic_payload)),
+                });
+            }
+        };
+
+        Ok(FormattedFile {
+            changed: source_code != formatted,
+            content: formatted,
+        })
     }
 
     pub fn format_one(source_code: &str, config: Config) -> String {
-        let ast_tree = Formatter::parse(source_code);
+        Self::try_format_source(source_code, config).unwrap_or_else(|message| panic!("{}", message))
+    }
+
+    fn try_format_source(source_code: &str, config: Config) -> Result<String, String> {
+        let ast_tree = Self::try_parse(source_code)?;
+        clear_thread_source_code();
+        clear_thread_comment_map();
+        let _thread_state_guard = ThreadStateGuard;
+
         set_thread_source_code(source_code.to_string()); // important to set thread level source code now;
 
         let mut cursor = ast_tree.walk();
@@ -162,10 +240,14 @@ impl Formatter {
 
         assert_no_missing_comments();
 
-        result
+        Ok(result)
     }
 
     pub fn parse(source_code: &str) -> Tree {
+        Self::try_parse(source_code).unwrap_or_else(|message| panic!("{}", message))
+    }
+
+    fn try_parse(source_code: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
         let language_fn = tree_sitter_sfapex::apex::LANGUAGE;
         parser
@@ -179,7 +261,7 @@ impl Formatter {
             if let Some(error_node) = Self::find_last_error_node(root_node) {
                 let error_snippet =
                     truncate_snippet(&source_code[error_node.start_byte()..error_node.end_byte()]);
-                println!(
+                let mut diagnostic = format!(
                     "Error in node kind: {}, at byte range: {}-{}, snippet: {}",
                     yellow(error_node.kind()),
                     error_node.start_byte(),
@@ -189,19 +271,23 @@ impl Formatter {
                 if let Some(p) = error_node.parent() {
                     let parent_snippet =
                         truncate_snippet(&source_code[p.start_byte()..p.end_byte()]);
-                    println!(
-                        "Parent node kind: {}, at byte range: {}-{}, snippet: {}",
+                    diagnostic.push_str(&format!(
+                        "\nParent node kind: {}, at byte range: {}-{}, snippet: {}",
                         yellow(p.kind()),
                         p.start_byte(),
                         p.end_byte(),
                         parent_snippet,
-                    );
+                    ));
                 }
+                return Err(format!(
+                    "{}\n{}",
+                    diagnostic,
+                    red("Parser encounters an error node in the tree.")
+                ));
             }
-            panic!("{}", red("Parser encounters an error node in the tree."));
         }
 
-        ast_tree
+        Ok(ast_tree)
     }
 
     fn find_last_error_node<'tree>(node: &Node<'tree>) -> Option<Node<'tree>> {
@@ -220,5 +306,255 @@ impl Formatter {
         }
 
         last_error_node // Return the last (deepest) error node
+    }
+}
+
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, Formatter};
+    use rayon::prelude::*;
+    #[cfg(unix)]
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temporary_directory() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!("sf-afmt-phase1-{unique}"));
+        fs::create_dir(&directory).expect("temporary directory should be created");
+        directory
+    }
+
+    #[test]
+    fn path_aware_results_keep_input_order_and_content_associations() {
+        let directory = temporary_directory();
+        let source = include_str!("../tests/static/variable_declaration.in");
+        let first_path = directory.join("first.cls");
+        let second_path = directory.join("second.cls");
+        fs::write(&first_path, source.replace("class A", "class First"))
+            .expect("first source should be written");
+        fs::write(&second_path, source.replace("class A", "class Second"))
+            .expect("second source should be written");
+
+        let formatter = Formatter::new(
+            Config::default(),
+            vec![
+                first_path.to_string_lossy().into_owned(),
+                second_path.to_string_lossy().into_owned(),
+            ],
+        );
+        let outcomes = formatter.format_with_outcomes();
+
+        assert_eq!(outcomes.len(), 2);
+        assert_eq!(outcomes[0].path, first_path);
+        assert_eq!(outcomes[1].path, second_path);
+        assert!(outcomes.iter().all(|outcome| outcome.result.is_ok()));
+        assert!(outcomes.iter().all(|outcome| {
+            outcome
+                .result
+                .as_ref()
+                .expect("outcome should succeed")
+                .changed
+        }));
+        assert!(outcomes[0]
+            .result
+            .as_ref()
+            .expect("first outcome should succeed")
+            .content
+            .contains("class First"));
+        assert!(outcomes[1]
+            .result
+            .as_ref()
+            .expect("second outcome should succeed")
+            .content
+            .contains("class Second"));
+
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
+
+    #[test]
+    fn compatibility_format_returns_results_in_input_order() {
+        let directory = temporary_directory();
+        let source = include_str!("../tests/static/variable_declaration.in");
+        let first_path = directory.join("first.cls");
+        let second_path = directory.join("second.cls");
+        fs::write(&first_path, source.replace("class A", "class First"))
+            .expect("first source should be written");
+        fs::write(&second_path, source.replace("class A", "class Second"))
+            .expect("second source should be written");
+
+        let formatter = Formatter::new(
+            Config::default(),
+            vec![
+                first_path.to_string_lossy().into_owned(),
+                second_path.to_string_lossy().into_owned(),
+            ],
+        );
+        let results = crate::format(formatter);
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0]
+            .as_ref()
+            .expect("first result should succeed")
+            .contains("class First"));
+        assert!(results[1]
+            .as_ref()
+            .expect("second result should succeed")
+            .contains("class Second"));
+
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
+
+    #[test]
+    fn formatted_results_report_unchanged_content() {
+        let directory = temporary_directory();
+        let source = include_str!("../tests/static/variable_declaration.in");
+        let path = directory.join("formatted.cls");
+        fs::write(&path, source).expect("source should be written");
+
+        let first = Formatter::try_format_one(&path, Config::default())
+            .expect("first formatting should succeed");
+        fs::write(&path, &first.content).expect("formatted source should be written");
+        let second = Formatter::try_format_one(&path, Config::default())
+            .expect("second formatting should succeed");
+
+        assert!(first.changed);
+        assert!(!second.changed);
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
+
+    #[test]
+    fn parse_errors_are_path_aware_and_do_not_stop_other_files() {
+        let directory = temporary_directory();
+        let invalid_path = directory.join("invalid.cls");
+        let valid_path = directory.join("valid.cls");
+        fs::write(&invalid_path, "class Broken {").expect("invalid source should be written");
+        fs::write(
+            &valid_path,
+            include_str!("../tests/static/variable_declaration.in"),
+        )
+        .expect("valid source should be written");
+
+        let outcomes = Formatter::new(
+            Config::default(),
+            vec![
+                invalid_path.to_string_lossy().into_owned(),
+                valid_path.to_string_lossy().into_owned(),
+            ],
+        )
+        .format_with_outcomes();
+
+        let error = outcomes[0]
+            .result
+            .as_ref()
+            .expect_err("invalid source should fail");
+        assert_eq!(error.path, invalid_path);
+        assert!(error.message.contains("byte range"));
+        assert!(error.message.contains("Parser encounters an error node"));
+        assert!(outcomes[1].result.is_ok());
+
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
+
+    #[test]
+    fn unexpected_formatting_panics_are_path_aware() {
+        let directory = temporary_directory();
+        let path = directory.join("panic.cls");
+        fs::write(
+            &path,
+            include_str!("../tests/static/variable_declaration.in"),
+        )
+        .expect("source should be written");
+
+        let error = Formatter::try_format_one(
+            &path,
+            Config {
+                max_width: 80,
+                indent_size: 0,
+            },
+        )
+        .expect_err("invalid formatter configuration should panic in the formatter");
+
+        assert_eq!(error.path, path);
+        assert!(error.message.contains("Formatting panicked"));
+        assert!(error.message.contains("indent_size must be greater than 0"));
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
+
+    #[test]
+    fn reused_workers_release_formatting_state() {
+        let directory = temporary_directory();
+        let path = directory.join("reused.cls");
+        fs::write(
+            &path,
+            include_str!("../tests/static/variable_declaration.in"),
+        )
+        .expect("source should be written");
+
+        let cleanup_checks = (0..32)
+            .into_par_iter()
+            .map(|_| {
+                let result = Formatter::try_format_one(&path, Config::default());
+                (result.is_ok(), crate::utility::thread_state_is_empty())
+            })
+            .collect::<Vec<_>>();
+
+        assert!(cleanup_checks
+            .iter()
+            .all(|(formatted, cleaned)| *formatted && *cleaned));
+        assert!(crate::utility::thread_state_is_empty());
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_native_constructor_preserves_non_utf8_paths() {
+        let directory = temporary_directory();
+        let path = directory.join(OsString::from_vec(vec![
+            b'n', b'o', b'n', b'-', 0xff, b'.', b'c', b'l', b's',
+        ]));
+        fs::write(
+            &path,
+            include_str!("../tests/static/variable_declaration.in"),
+        )
+        .expect("source should be written");
+
+        let outcome = Formatter::new_from_paths(Config::default(), vec![path.clone()])
+            .format_with_outcomes()
+            .pop()
+            .expect("one outcome should be returned");
+
+        assert_eq!(outcome.path, path);
+        assert!(outcome.result.is_ok());
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
+
+    #[test]
+    fn path_aware_results_include_read_errors() {
+        let path = std::env::temp_dir().join("sf-afmt-phase1-file-that-does-not-exist.cls");
+        let outcome = Formatter::new(Config::default(), vec![path.to_string_lossy().into_owned()])
+            .format_with_outcomes()
+            .pop()
+            .expect("one outcome should be returned");
+
+        let error = outcome.result.expect_err("missing input should fail");
+        assert_eq!(error.path, path);
+        assert!(error.message.contains("Failed to read file"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 mod accessor;
 pub mod args;
+pub mod config;
 mod context;
 mod data_model;
+pub mod discovery;
 mod doc;
 mod doc_builder;
 mod enum_def;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use sf_afmt::args::{get_args, Args};
-use sf_afmt::format;
+use sf_afmt::config::AfmtConfig;
+use sf_afmt::discovery::{discover_targets, DiscoveryConfigError};
 use sf_afmt::formatter::Formatter;
+use std::io::{self, Write};
 use std::time::Instant;
 use std::{fs, process};
 
@@ -8,57 +10,241 @@ fn main() {
     let start = Instant::now();
 
     let args = get_args();
-    let result = run(&args);
+    let result = run(&args, start);
 
     match result {
-        Ok(_) => {
-            if args.time {
-                let duration = start.elapsed();
-                println!("\n-- Execution time: {:?}", duration);
-            }
-            process::exit(0);
-        }
-        Err(e) => {
-            eprint!("Error: {}", e);
+        Ok(summary) => process::exit(if summary.has_failures() { 1 } else { 0 }),
+        Err(error) => {
+            eprintln!("Error: {error}");
             process::exit(1);
         }
     }
 }
 
-fn run(args: &Args) -> Result<(), String> {
-    let formatter = Formatter::create_from_config(args.config.as_deref(), vec![args.path.clone()])?;
-    let results = format(formatter);
+#[derive(Debug, Default)]
+struct RunSummary {
+    selected: usize,
+    changed: usize,
+    written: usize,
+    unchanged: usize,
+    failed: usize,
+    check_failed: usize,
+    diagnostics: Vec<String>,
+}
 
-    for (index, result) in results.iter().enumerate() {
-        match result {
-            Ok(value) => {
-                if args.check {
-                    let original_content = fs::read_to_string(&args.path)
-                        .map_err(|e| format!("Failed to read file {}: {}", args.path, e))?;
+impl RunSummary {
+    fn has_failures(&self) -> bool {
+        self.failed > 0 || self.check_failed > 0
+    }
 
-                    if original_content.as_str() == value {
-                        println!("File is already formatted: {}", args.path);
-                        return Ok(());
-                    } else {
-                        eprintln!("File is not correctly formatted: {}", args.path);
-                        return Err("Formatting check failed".to_string());
-                    }
-                } else if args.write {
-                    fs::write(&args.path, value).map_err(|e| {
-                        format!("Failed to write formatted content to {}: {}", args.path, e)
-                    })?;
-                    println!("Formatted content written back to: {}\n", args.path);
+    fn record_error(&mut self, message: String) {
+        self.failed += 1;
+        eprintln!("Error: {message}");
+        self.diagnostics.push(message);
+    }
+
+    fn print(&self, elapsed: std::time::Duration) {
+        eprintln!(
+            "Summary: selected={}, changed={}, written={}, unchanged={}, failed={}, total_elapsed={:?}",
+            self.selected,
+            self.changed,
+            self.written,
+            self.unchanged,
+            self.failed,
+            elapsed
+        );
+    }
+}
+
+fn run(args: &Args, started: Instant) -> Result<RunSummary, String> {
+    run_with_writer(args, started, |path, content| fs::write(path, content))
+}
+
+fn run_with_writer<F>(args: &Args, started: Instant, write_file: F) -> Result<RunSummary, String>
+where
+    F: Fn(&std::path::Path, &str) -> std::io::Result<()>,
+{
+    let app_config = AfmtConfig::load(args.config.as_deref())?;
+    let base = AfmtConfig::base_dir(args.config.as_deref())?;
+    let report = discover_targets(&args.paths, &app_config.files, &base)
+        .map_err(|error: DiscoveryConfigError| error.to_string())?;
+    let formatter = Formatter::new_from_paths(app_config.formatter, report.files.clone());
+    let outcomes = formatter.format_with_outcomes();
+    let single_output = outcomes.len() == 1;
+    let mut summary = RunSummary {
+        selected: outcomes.len(),
+        ..RunSummary::default()
+    };
+    let bulk = args.paths.len() > 1
+        || outcomes.len() > 1
+        || args.paths.first().is_some_and(|path| path.is_dir());
+
+    for error in report.errors {
+        summary.record_error(error.to_string());
+    }
+
+    for outcome in outcomes {
+        let path = outcome.path.clone();
+        match outcome.result {
+            Ok(formatted) if args.check && formatted.changed => {
+                summary.changed += 1;
+                summary.check_failed += 1;
+                eprintln!("Unformatted: {}", path.display());
+            }
+            Ok(_formatted) if args.check => {
+                summary.unchanged += 1;
+            }
+            Ok(formatted) if args.write && formatted.changed => {
+                summary.changed += 1;
+                if let Err(error) = write_file(&path, &formatted.content) {
+                    summary.record_error(format!(
+                        "{}: failed to write file: {}",
+                        path.display(),
+                        error
+                    ));
                 } else {
-                    //println!("Result {}: Ok\n{}", index, value);
-                    println!("{}", value);
+                    summary.written += 1;
                 }
             }
-            Err(e) => {
-                //println!("Result {}: Err\n{}", index, e);
-                return Err(format!("Error processing result {}: {}", index, e));
+            Ok(_formatted) if args.write => {
+                summary.unchanged += 1;
             }
+            Ok(formatted) => {
+                if formatted.changed {
+                    summary.changed += 1;
+                } else {
+                    summary.unchanged += 1;
+                }
+                if single_output {
+                    print_source(&formatted.content);
+                } else {
+                    println!("==> {} <==", path.display());
+                    print_source(&formatted.content);
+                }
+            }
+            Err(error) => {
+                summary.record_error(error.to_string());
+            }
+        }
+
+        if args.time {
+            eprintln!("Timing: {} {:?}", path.display(), outcome.elapsed);
         }
     }
 
-    Ok(())
+    if args.check {
+        eprintln!(
+            "Check: {} file(s) would be reformatted",
+            summary.check_failed
+        );
+    }
+
+    let elapsed = started.elapsed();
+    if bulk || args.time {
+        summary.print(elapsed);
+    }
+    if args.time {
+        eprintln!("Total elapsed: {elapsed:?}");
+    }
+
+    Ok(summary)
+}
+
+fn print_source(content: &str) {
+    print!("{content}");
+    if !content.ends_with('\n') {
+        println!();
+    }
+    io::stdout()
+        .flush()
+        .expect("formatted output should be flushed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_with_writer, Args};
+    use sf_afmt::formatter::{Config, Formatter};
+    use std::fs;
+    use std::io;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temporary_directory() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!("sf-afmt-phase3-write-{unique}"));
+        fs::create_dir(&directory).expect("temporary directory should be created");
+        directory
+    }
+
+    #[test]
+    fn write_policy_handles_changed_unchanged_and_injected_write_error() {
+        let directory = temporary_directory();
+        let blocked = directory.join("a-blocked.cls");
+        let written = directory.join("b-written.cls");
+        let unchanged = directory.join("c-unchanged.cls");
+        let source = include_str!("../tests/static/variable_declaration.in");
+        fs::write(&blocked, source).expect("blocked source should be written");
+        fs::write(&written, source).expect("writable source should be written");
+
+        let formatted =
+            Formatter::try_format_one(&written, Config::default()).expect("fixture should format");
+        fs::write(&unchanged, &formatted.content).expect("formatted source should be written");
+        let unchanged_content = fs::read(&unchanged).expect("unchanged source should be readable");
+        let unchanged_time = fs::metadata(&unchanged)
+            .expect("unchanged metadata should be readable")
+            .modified()
+            .expect("unchanged timestamp should be available");
+        let blocked_for_writer = blocked.clone();
+
+        let args = Args {
+            paths: vec![directory.clone()],
+            config: None,
+            write: true,
+            time: false,
+            check: false,
+        };
+        let summary = run_with_writer(&args, std::time::Instant::now(), |path, content| {
+            if path == blocked_for_writer {
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "injected failure",
+                ))
+            } else {
+                fs::write(path, content)
+            }
+        })
+        .expect("write run should complete with per-file failures");
+
+        assert!(summary.has_failures());
+        assert_eq!(summary.selected, 3);
+        assert_eq!(summary.changed, 2);
+        assert_eq!(summary.written, 1);
+        assert_eq!(summary.unchanged, 1);
+        assert_eq!(summary.failed, 1);
+        assert!(summary
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("a-blocked.cls")
+                && diagnostic.contains("failed to write file")));
+        assert_eq!(
+            fs::read(&written).expect("written source should be readable"),
+            formatted.content.as_bytes()
+        );
+        assert_eq!(
+            fs::read(&unchanged).expect("unchanged source should be readable"),
+            unchanged_content
+        );
+        assert_eq!(
+            fs::metadata(&unchanged)
+                .expect("unchanged metadata should be readable")
+                .modified()
+                .expect("unchanged timestamp should be available"),
+            unchanged_time
+        );
+
+        fs::remove_dir_all(directory).expect("temporary directory should be removed");
+    }
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -99,7 +99,7 @@ pub fn print_comment_map(tree: &Tree) {
     }
 }
 
-fn build_id_node_map(ast_tree: &Tree) -> HashMap<usize, Node> {
+fn build_id_node_map(ast_tree: &Tree) -> HashMap<usize, Node<'_>> {
     let mut cursor = ast_tree.walk();
     let mut node_map = HashMap::new();
 

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -7,7 +7,7 @@ use crate::{
     enum_def::{Comparison, SetValue, SoqlLiteral, ValueComparedWith},
     message_helper::{red, yellow},
 };
-use std::{cell::Cell, collections::HashMap};
+use std::{cell::RefCell, collections::HashMap};
 use tree_sitter::{Node, Tree, TreeCursor};
 
 const SNIPPET_MAX_LEN: usize = 80;
@@ -16,54 +16,87 @@ pub fn truncate_snippet(snippet: &str) -> String {
     if snippet.len() <= SNIPPET_MAX_LEN {
         snippet.to_string()
     } else {
-        format!("{}…", &snippet[..SNIPPET_MAX_LEN])
+        let end = snippet
+            .char_indices()
+            .take_while(|(index, character)| index + character.len_utf8() <= SNIPPET_MAX_LEN)
+            .map(|(index, character)| index + character.len_utf8())
+            .last()
+            .unwrap_or(0);
+        format!("{}…", &snippet[..end])
     }
 }
 
 thread_local! {
-    static THREAD_SOURCE_CODE: Cell<Option<&'static str>>
-        = const{ Cell::new(None) };
+    static THREAD_SOURCE_CODE: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 pub fn set_thread_source_code(source_code: String) {
-    // TODO: use OnceCell to not leak?
-    let leaked_code: &'static str = Box::leak(source_code.into_boxed_str());
     THREAD_SOURCE_CODE.with(|sc| {
-        if sc.get().is_some() {
+        let mut source = sc.borrow_mut();
+        if source.is_some() {
             panic!("Source code is already set for this thread");
         }
-        sc.set(Some(leaked_code));
+        *source = Some(source_code);
     });
 }
 
-pub fn get_source_code() -> &'static str {
-    THREAD_SOURCE_CODE.with(|sc| sc.get().expect("Source code not set for this thread"))
+pub fn clear_thread_source_code() {
+    THREAD_SOURCE_CODE.with(|sc| sc.borrow_mut().take());
+}
+
+pub fn with_source_code<T>(callback: impl FnOnce(&str) -> T) -> T {
+    THREAD_SOURCE_CODE.with(|sc| {
+        let source = sc.borrow();
+        callback(
+            source
+                .as_deref()
+                .expect("Source code not set for this thread"),
+        )
+    })
 }
 
 thread_local! {
-    static THREAD_COMMENT_MAP: Cell<Option<&'static CommentMap>> = const{ Cell::new(None) };
+    static THREAD_COMMENT_MAP: RefCell<Option<CommentMap>> = const { RefCell::new(None) };
 }
 
 pub fn set_thread_comment_map(comment_map: CommentMap) {
-    // TODO: use OnceCell to not leak?
-    let leaked_map: &'static CommentMap = Box::leak(Box::new(comment_map));
-
     THREAD_COMMENT_MAP.with(|cm| {
-        if cm.get().is_some() {
+        let mut comment_map_slot = cm.borrow_mut();
+        if comment_map_slot.is_some() {
             panic!("CommentMap is already set for this thread");
         }
-        cm.set(Some(leaked_map));
+        *comment_map_slot = Some(comment_map);
     });
 }
 
-pub fn get_comment_bucket(node_id: &usize) -> &CommentBucket {
-    get_comment_map()
-        .get(node_id)
-        .unwrap_or_else(|| panic!("## comment_map missing bucket for node: {}", node_id))
+pub fn clear_thread_comment_map() {
+    THREAD_COMMENT_MAP.with(|cm| cm.borrow_mut().take());
 }
 
-pub fn get_comment_map() -> &'static CommentMap {
-    THREAD_COMMENT_MAP.with(|cm| cm.get().expect("## CommentMap not set for this thread"))
+#[cfg(test)]
+pub fn thread_state_is_empty() -> bool {
+    let source_empty = THREAD_SOURCE_CODE.with(|sc| sc.borrow().is_none());
+    let comments_empty = THREAD_COMMENT_MAP.with(|cm| cm.borrow().is_none());
+    source_empty && comments_empty
+}
+
+pub fn get_comment_bucket(node_id: &usize) -> CommentBucket {
+    THREAD_COMMENT_MAP.with(|cm| {
+        cm.borrow()
+            .as_ref()
+            .and_then(|comment_map| comment_map.get(node_id))
+            .cloned()
+            .unwrap_or_else(|| panic!("## comment_map missing bucket for node: {}", node_id))
+    })
+}
+
+pub fn get_comment_map() -> CommentMap {
+    THREAD_COMMENT_MAP.with(|cm| {
+        cm.borrow()
+            .as_ref()
+            .cloned()
+            .expect("## CommentMap not set for this thread")
+    })
 }
 
 #[allow(dead_code)]
@@ -99,7 +132,7 @@ pub fn print_comment_map(tree: &Tree) {
     }
 }
 
-fn build_id_node_map(ast_tree: &Tree) -> HashMap<usize, Node> {
+fn build_id_node_map(ast_tree: &Tree) -> HashMap<usize, Node<'_>> {
     let mut cursor = ast_tree.walk();
     let mut node_map = HashMap::new();
 
@@ -120,7 +153,7 @@ fn build_id_node_map(ast_tree: &Tree) -> HashMap<usize, Node> {
 }
 
 pub fn assert_no_missing_comments() {
-    let missing_comments: Vec<&'static Comment> = get_comment_map()
+    let missing_comments: Vec<Comment> = get_comment_map()
         .values()
         .flat_map(|bucket| {
             bucket
@@ -129,7 +162,8 @@ pub fn assert_no_missing_comments() {
                 .chain(bucket.post_comments.iter())
                 .chain(bucket.dangling_comments.iter())
         })
-        .filter(|comment| !comment.is_printed())
+        .filter(|&comment| !comment.is_printed())
+        .cloned()
         .collect();
 
     if !missing_comments.is_empty() {
@@ -286,16 +320,16 @@ pub fn build_with_comments<'a, F>(
     F: FnOnce(&'a DocBuilder<'a>, &mut Vec<DocRef<'a>>),
 {
     let bucket = get_comment_bucket(&node_context.id);
-    handle_pre_comments(b, bucket, result);
+    handle_pre_comments(b, &bucket, result);
 
     if bucket.dangling_comments.is_empty() {
         handle_members(b, result);
     } else {
-        result.push(b.concat(handle_dangling_comments(b, bucket)));
+        result.push(b.concat(handle_dangling_comments(b, &bucket)));
         return;
     }
 
-    handle_post_comments(b, bucket, result);
+    handle_post_comments(b, &bucket, result);
 }
 
 pub fn build_with_comments_core<'a, F>(
@@ -307,12 +341,12 @@ pub fn build_with_comments_core<'a, F>(
     F: FnOnce(&'a DocBuilder<'a>, &mut Vec<DocRef<'a>>),
 {
     let bucket = get_comment_bucket(&node_context.id);
-    handle_pre_comments(b, bucket, result);
+    handle_pre_comments(b, &bucket, result);
 
     if bucket.dangling_comments.is_empty() {
         handle_members(b, result);
     } else {
-        result.push(b.concat(handle_dangling_comments(b, bucket)));
+        result.push(b.concat(handle_dangling_comments(b, &bucket)));
     }
 }
 
@@ -328,7 +362,7 @@ pub fn build_with_comments_and_punc<'a, F>(
 
     let bucket = get_comment_bucket(&node_context.id);
     if bucket.dangling_comments.is_empty() {
-        handle_post_comments(b, bucket, result);
+        handle_post_comments(b, &bucket, result);
     }
 
     if let Some(ref n) = node_context.punc {
@@ -354,7 +388,7 @@ pub fn build_with_comments_and_punc_attached<'a, F>(
     }
 
     if bucket.dangling_comments.is_empty() {
-        handle_post_comments(b, bucket, result);
+        handle_post_comments(b, &bucket, result);
     }
 }
 
@@ -594,4 +628,18 @@ pub fn is_bracket_composite_node(node: &Node) -> bool {
         node.kind(),
         "trigger_body" | "class_body" | "block" | "enum_body"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_snippet;
+
+    #[test]
+    fn truncate_snippet_never_splits_unicode() {
+        let snippet = format!("{}é", "a".repeat(79));
+        let truncated = truncate_snippet(&snippet);
+
+        assert_eq!(truncated, format!("{}…", "a".repeat(79)));
+        assert!(std::str::from_utf8(truncated.as_bytes()).is_ok());
+    }
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -216,6 +216,8 @@ pub fn collect_comments(cursor: &mut TreeCursor, comment_map: &mut CommentMap) {
                     } else {
                         // Otherwise, the sibling is a named node, no special treatment needed
                         if child.end_position().row == last_row {
+                            let mut c = c;
+                            c.mark_as_inline_post_comment();
                             comment_map
                                 .entry(last_id)
                                 .or_insert_with(CommentBucket::new)
@@ -228,8 +230,27 @@ pub fn collect_comments(cursor: &mut TreeCursor, comment_map: &mut CommentMap) {
                     }
                 }
             } else {
-                // There's no "last associable node" yet, so keep it pending
-                pending_pre_comments.push(comment);
+                // A comment on the same line as an `else` belongs after the
+                // keyword, even when the parser nests the comment under the
+                // following statement.
+                if let Some(previous) = node.prev_sibling() {
+                    if previous.kind() == "else"
+                        && child.start_position().row == previous.end_position().row
+                    {
+                        let mut comment = comment;
+                        comment.mark_as_inline_post_comment();
+                        comment_map
+                            .entry(previous.id())
+                            .or_insert_with(CommentBucket::new)
+                            .post_comments
+                            .push(comment);
+                    } else {
+                        pending_pre_comments.push(comment);
+                    }
+                } else {
+                    // There's no "last associable node" yet, so keep it pending
+                    pending_pre_comments.push(comment);
+                }
             }
         } else if child.is_named() || is_associable_unnamed_node(&child) {
             // It's an associable node

--- a/tests/battle_test/.afmt.toml
+++ b/tests/battle_test/.afmt.toml
@@ -1,0 +1,8 @@
+# Battle-test selection mirrors the legacy find pruning while retaining afmt's
+# built-in repository exclusions.
+max_width = 80
+indent_size = 2
+
+[files]
+include = ["**/*.cls", "**/*.trigger", "**/*.apex", "**/*.apexc"]
+exclude = ["**/.git/**", "**/.sfdx/**", "**/node_modules/**", "**/scripts/**"]

--- a/tests/battle_test/README.md
+++ b/tests/battle_test/README.md
@@ -1,0 +1,35 @@
+# Battle tests
+
+`battle_testing.sh` clones the disposable repositories listed in
+`repos.txt`, runs one bulk directory formatting command, and redirects
+formatted stdout. The selection is configured by `.afmt.toml`; it preserves
+the legacy `.sfdx` and `scripts` pruning in addition to afmt's standard
+repository exclusions.
+
+If the bulk command reports a failure, the script captures its stderr and runs
+the legacy per-file classifier. That fallback recognizes tolerated managed
+package template markers such as `%%` while retaining detailed diagnostics for
+unexpected files. A successful bulk command does not start per-file processes.
+
+For disposable clones, `--idempotent` runs bulk `--write` followed by bulk
+`--check`. If either bulk command fails, the existing per-file idempotency
+diagnostic runs to identify the affected files.
+
+## Local benchmark
+
+The benchmark builds the release binary once, then compares a sequential
+process-per-file dry run with one bulk dry run over the same corpus and
+exclusions. It performs one warm-up and five measured runs by default, and
+reports each run, file count, median wall time, and relative speedup. The
+measured run count must be odd and at least three so the reported median is
+unambiguous; set `AFMT_BENCH_RUNS` to another odd count when needed.
+
+Required tools: Bash 4+, Cargo/Rust, `find`, `sort`, `awk`, and either GNU
+`date` with nanosecond output or Python 3. Example:
+
+```bash
+AFMT_BENCH_RUNS=7 ./tests/battle_test/benchmark_bulk.sh /path/to/local/apex-repo
+```
+
+The benchmark performs dry runs only; the corpus is not modified. Build,
+clone, and download time is excluded from measured runs.

--- a/tests/battle_test/battle_testing.sh
+++ b/tests/battle_test/battle_testing.sh
@@ -13,6 +13,8 @@ REPO_LIST="$SCRIPT_DIR/repos.txt"
 TARGET_DIR="$SCRIPT_DIR/repos"
 FORMATTER_BINARY="$SCRIPT_DIR/../../target/debug/afmt"
 LOG_FILE="$SCRIPT_DIR/format_errors.log"
+BATTLE_CONFIG="$SCRIPT_DIR/.afmt.toml"
+BULK_ERROR_LOG="$SCRIPT_DIR/bulk_errors.log"
 
 # Enhanced error handling function
 handle_error() {
@@ -163,21 +165,64 @@ export -f format_files
 export -f idempotent_test
 export FORMATTER_BINARY
 export LOG_FILE
+export BATTLE_CONFIG
 # export LONG_LINES_LOG_FILE
 # export LINE_LENGTH
 
 # Record the start time
 START_TIME=$(date +%s)
 
-# Find all .cls and .trigger files and process them in parallel
-find "$TARGET_DIR" \( -type d \( -name ".sfdx" -o -name "scripts" \) \) -prune -o -type f \( -name "*.cls" -o -name "*.trigger" \) -print0 | \
-    parallel -0 -j+0 format_files
+# The normal path exercises one bulk invocation. Its output is redirected
+# because this script validates formatting success, not rendered source.
+# If the aggregate command fails, retain its stderr and run the legacy
+# per-file classifier so tolerated managed-package templates still work and
+# unexpected failures retain file-specific diagnostics.
+run_bulk_format() {
+    set +e
+    "$FORMATTER_BINARY" --config "$BATTLE_CONFIG" "$TARGET_DIR" \
+        > /dev/null 2> "$BULK_ERROR_LOG"
+    local exit_code=$?
+    set -e
+    return "$exit_code"
+}
+
+if ! run_bulk_format; then
+    echo "Bulk formatting reported failures; running diagnostic fallback."
+    cat "$BULK_ERROR_LOG"
+    find "$TARGET_DIR" \( -type d \( -name ".sfdx" -o -name "scripts" \) \) -prune -o \
+        -type f \( -name "*.cls" -o -name "*.trigger" -o -name "*.apex" -o -name "*.apexc" \) -print0 | \
+        parallel -0 -j+0 format_files
+fi
 
 # Run idempotent testing if mode is activated
 if [ "$IDEMPOTENT_MODE" = true ]; then
-    echo "Running idempotency tests..."
-    find "$TARGET_DIR" \( -type d \( -name ".sfdx" -o -name "scripts" \) \) -prune -o -type f \( -name "*.cls" -o -name "*.trigger" \) -print0 | \
-        parallel -0 -j+0 idempotent_test
+    echo "Running bulk write/check idempotency tests..."
+    IDEMPOTENT_WRITE_LOG="$SCRIPT_DIR/idempotent_write_errors.log"
+    IDEMPOTENT_CHECK_LOG="$SCRIPT_DIR/idempotent_check_errors.log"
+    : > "$IDEMPOTENT_WRITE_LOG"
+    : > "$IDEMPOTENT_CHECK_LOG"
+    set +e
+    "$FORMATTER_BINARY" --config "$BATTLE_CONFIG" --write "$TARGET_DIR" \
+        > /dev/null 2> "$IDEMPOTENT_WRITE_LOG"
+    WRITE_EXIT_CODE=$?
+    if [ "$WRITE_EXIT_CODE" -eq 0 ]; then
+        "$FORMATTER_BINARY" --config "$BATTLE_CONFIG" --check "$TARGET_DIR" \
+            > /dev/null 2> "$IDEMPOTENT_CHECK_LOG"
+        CHECK_EXIT_CODE=$?
+    else
+        CHECK_EXIT_CODE=1
+    fi
+    set -e
+
+    if [ "$WRITE_EXIT_CODE" -ne 0 ] || [ "$CHECK_EXIT_CODE" -ne 0 ]; then
+        echo "Bulk idempotency check reported failures; running detailed fallback."
+        cat "$IDEMPOTENT_WRITE_LOG" "$IDEMPOTENT_CHECK_LOG"
+        find "$TARGET_DIR" \( -type d \( -name ".sfdx" -o -name "scripts" \) \) -prune -o \
+            -type f \( -name "*.cls" -o -name "*.trigger" -o -name "*.apex" -o -name "*.apexc" \) -print0 | \
+            parallel -0 -j+0 idempotent_test
+    else
+        echo "Bulk write/check idempotency passed."
+    fi
 fi
 
 # find "$TARGET_DIR" -path "$TARGET_DIR/.sfdx" -prune -o -type f \( -name "*.cls" -o -name "*.trigger" \) -print0 | \

--- a/tests/battle_test/benchmark_bulk.sh
+++ b/tests/battle_test/benchmark_bulk.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Compare the legacy sequential process-per-file path with one bulk afmt run.
+# Both strategies use the same extensions, exclusions, config, and disposable
+# dry-run behavior, so the corpus is not modified during measurement.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CORPUS_DIR="${1:-}"
+RUNS="${AFMT_BENCH_RUNS:-5}"
+FORMATTER_BINARY="$PROJECT_DIR/target/release/afmt"
+BATTLE_CONFIG="$SCRIPT_DIR/.afmt.toml"
+
+if [ -z "$CORPUS_DIR" ] || [ ! -d "$CORPUS_DIR" ]; then
+    echo "Usage: $0 CORPUS_DIRECTORY" >&2
+    exit 2
+fi
+if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || (( 10#$RUNS < 3 )) || (( 10#$RUNS % 2 == 0 )); then
+    echo "AFMT_BENCH_RUNS must be an odd integer of at least 3" >&2
+    exit 2
+fi
+
+CORPUS_DIR="$(cd "$CORPUS_DIR" && pwd)"
+
+echo "Building release binary..."
+(cd "$PROJECT_DIR" && cargo build --release --bin afmt)
+
+if ! command -v sort >/dev/null || ! command -v find >/dev/null; then
+    echo "benchmark requires find and sort" >&2
+    exit 2
+fi
+
+mapfile -d '' FILES < <(
+    find "$CORPUS_DIR" \
+        \( -type d \( -name ".git" -o -name ".sfdx" -o -name "node_modules" -o -name "scripts" \) -prune \) -o \
+        -type f \( -name "*.cls" -o -name "*.trigger" -o -name "*.apex" -o -name "*.apexc" \) -print0
+)
+FILE_COUNT="${#FILES[@]}"
+if [ "$FILE_COUNT" -eq 0 ]; then
+    echo "No supported Apex files found in $CORPUS_DIR" >&2
+    exit 1
+fi
+
+now_ns() {
+    local value
+    value="$(date +%s%N 2>/dev/null || true)"
+    if [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "$value"
+    elif command -v python3 >/dev/null; then
+        python3 -c 'import time; print(time.time_ns())'
+    else
+        echo "A nanosecond clock or Python 3 is required" >&2
+        exit 2
+    fi
+}
+
+run_baseline() {
+    local file
+    for file in "${FILES[@]}"; do
+        "$FORMATTER_BINARY" --config "$BATTLE_CONFIG" "$file" > /dev/null 2>&1
+    done
+}
+
+run_bulk() {
+    "$FORMATTER_BINARY" --config "$BATTLE_CONFIG" "$CORPUS_DIR" > /dev/null 2>&1
+}
+
+measure() {
+    local label="$1"
+    local start end elapsed
+    start="$(now_ns)"
+    if [ "$label" = "baseline" ]; then
+        run_baseline
+    else
+        run_bulk
+    fi
+    end="$(now_ns)"
+    elapsed=$((end - start))
+    echo "$elapsed"
+}
+
+median() {
+    printf '%s\n' "$@" | sort -n | awk 'NR == (n + 1) / 2 { print; found = 1 } END { if (!found) print 0 }' n="$#"
+}
+
+echo "Corpus: $CORPUS_DIR"
+echo "Files: $FILE_COUNT"
+echo "Runs: $RUNS (one warm-up plus measured runs)"
+echo "Warm-up: baseline"
+measure baseline >/dev/null
+echo "Warm-up: bulk"
+measure bulk >/dev/null
+
+baseline_runs=()
+bulk_runs=()
+for ((run = 1; run <= RUNS; run++)); do
+    baseline_time="$(measure baseline)"
+    bulk_time="$(measure bulk)"
+    baseline_runs+=("$baseline_time")
+    bulk_runs+=("$bulk_time")
+    echo "Run $run: baseline=${baseline_time}ns bulk=${bulk_time}ns"
+done
+
+baseline_median="$(median "${baseline_runs[@]}")"
+bulk_median="$(median "${bulk_runs[@]}")"
+speedup="$(awk -v baseline="$baseline_median" -v bulk="$bulk_median" 'BEGIN { if (bulk == 0) print "inf"; else printf "%.2fx", baseline / bulk }')"
+
+echo "Median baseline: ${baseline_median}ns"
+echo "Median bulk: ${bulk_median}ns"
+echo "Relative speedup: ${speedup}"

--- a/tests/battle_test/benchmark_bulk_test.sh
+++ b/tests/battle_test/benchmark_bulk_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Lightweight validation for benchmark argument handling. This intentionally
+# stops before the release build so it can run in every test environment.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+if AFMT_BENCH_RUNS=4 "$SCRIPT_DIR/benchmark_bulk.sh" "$TEMP_DIR" > /dev/null 2> "$TEMP_DIR/error.log"; then
+    echo "benchmark accepted an even run count" >&2
+    exit 1
+fi
+
+grep -q "AFMT_BENCH_RUNS must be an odd integer of at least 3" "$TEMP_DIR/error.log"
+echo "benchmark run-count validation passed"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,258 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temporary_directory() -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after the Unix epoch")
+        .as_nanos();
+    let directory = std::env::temp_dir().join(format!("sf-afmt-phase3-{unique}"));
+    fs::create_dir(&directory).expect("temporary directory should be created");
+    directory
+}
+
+fn run_cli(directory: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_afmt"))
+        .current_dir(directory)
+        .args(args)
+        .output()
+        .expect("afmt should run")
+}
+
+fn write_fixture(path: &Path) {
+    fs::write(path, include_str!("static/variable_declaration.in"))
+        .expect("fixture should be written");
+}
+
+#[test]
+fn single_file_dry_run_keeps_stdout_as_plain_formatted_source() {
+    let directory = temporary_directory();
+    let path = directory.join("Account.cls");
+    write_fixture(&path);
+
+    let output = run_cli(&directory, &[path.to_str().unwrap()]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.starts_with("class A {"));
+    assert!(!stdout.contains("==>"));
+    assert!(output.stderr.is_empty());
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn multi_file_dry_run_is_delimited_and_sorted() {
+    let directory = temporary_directory();
+    let first = directory.join("z.cls");
+    let second = directory.join("a.cls");
+    write_fixture(&first);
+    write_fixture(&second);
+
+    let directory_arg = directory.to_str().unwrap();
+    let output = run_cli(&directory, &[directory_arg]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let first_delimiter = format!("==> {} <==", second.display());
+    let second_delimiter = format!("==> {} <==", first.display());
+    assert_eq!(stdout.matches("==> ").count(), 2);
+    assert!(stdout.contains(&first_delimiter));
+    assert!(stdout.contains(&second_delimiter));
+    assert!(stdout.find(&first_delimiter) < stdout.find(&second_delimiter));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Summary: selected=2"));
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn write_continues_after_a_format_failure_and_reports_summary() {
+    let directory = temporary_directory();
+    let invalid = directory.join("a-invalid.cls");
+    let valid = directory.join("b-valid.cls");
+    fs::write(&invalid, "class Broken {").expect("invalid fixture should be written");
+    write_fixture(&valid);
+    let original_valid = fs::read_to_string(&valid).expect("valid source should be readable");
+
+    let output = run_cli(&directory, &["--write", directory.to_str().unwrap()]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("a-invalid.cls"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Summary: selected=2"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("written=1"));
+    assert_ne!(
+        fs::read_to_string(&valid).expect("valid source should remain readable"),
+        original_valid
+    );
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn check_evaluates_every_file_and_reports_changed_count() {
+    let directory = temporary_directory();
+    let changed = directory.join("a-changed.cls");
+    let unchanged = directory.join("b-unchanged.cls");
+    write_fixture(&changed);
+    write_fixture(&unchanged);
+    let format_unchanged = run_cli(&directory, &["--write", unchanged.to_str().unwrap()]);
+    assert!(format_unchanged.status.success());
+
+    let output = run_cli(&directory, &["--check", directory.to_str().unwrap()]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("Unformatted:"));
+    assert!(stderr.contains("a-changed.cls"));
+    assert!(
+        stderr.contains("Check: 1 file(s) would be reformatted"),
+        "unexpected check diagnostics: {stderr}"
+    );
+    assert!(stderr.contains("Summary: selected=2, changed=1, written=0, unchanged=1, failed=0"));
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn check_lists_all_changed_paths_and_accepts_a_fully_formatted_file() {
+    let directory = temporary_directory();
+    let first_changed = directory.join("a-changed.cls");
+    let second_changed = directory.join("b-changed.cls");
+    let unchanged = directory.join("c-unchanged.cls");
+    write_fixture(&first_changed);
+    write_fixture(&second_changed);
+    write_fixture(&unchanged);
+
+    let unchanged_format = run_cli(&directory, &["--write", unchanged.to_str().unwrap()]);
+    assert!(unchanged_format.status.success());
+    let unchanged_bytes = fs::read(&unchanged).expect("unchanged source should be readable");
+    let changed_bytes = fs::read(&first_changed).expect("changed source should be readable");
+
+    let output = run_cli(&directory, &["--check", directory.to_str().unwrap()]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("a-changed.cls"));
+    assert!(stderr.contains("b-changed.cls"));
+    assert!(!stderr.contains("c-unchanged.cls"));
+    assert!(stderr.contains("Check: 2 file(s) would be reformatted"));
+    assert!(stderr.contains("Summary: selected=3, changed=2, written=0, unchanged=1, failed=0"));
+    assert_eq!(
+        fs::read(&unchanged).expect("unchanged source should be readable"),
+        unchanged_bytes
+    );
+    assert_eq!(
+        fs::read(&first_changed).expect("changed source should be readable"),
+        changed_bytes
+    );
+
+    let formatted_check = run_cli(&directory, &["--check", unchanged.to_str().unwrap()]);
+    assert!(formatted_check.status.success());
+    let formatted_stderr =
+        String::from_utf8(formatted_check.stderr).expect("stderr should be UTF-8");
+    assert!(formatted_stderr.contains("Check: 0 file(s) would be reformatted"));
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn check_parse_error_and_no_match_are_nonzero_without_writes() {
+    let directory = temporary_directory();
+    let invalid = directory.join("a-invalid.cls");
+    let valid = directory.join("b-valid.cls");
+    fs::write(&invalid, "class Broken {").expect("invalid source should be written");
+    write_fixture(&valid);
+    let valid_write = run_cli(&directory, &["--write", valid.to_str().unwrap()]);
+    assert!(valid_write.status.success());
+    let valid_bytes = fs::read(&valid).expect("valid source should be readable");
+
+    let parse_output = run_cli(&directory, &["--check", directory.to_str().unwrap()]);
+    assert!(!parse_output.status.success());
+    let parse_stderr = String::from_utf8(parse_output.stderr).expect("stderr should be UTF-8");
+    assert!(parse_stderr.contains("a-invalid.cls"));
+    assert!(
+        parse_stderr.contains("Summary: selected=2, changed=0, written=0, unchanged=1, failed=1")
+    );
+    assert_eq!(
+        fs::read(&valid).expect("valid source should remain readable"),
+        valid_bytes
+    );
+
+    let empty = directory.join("empty");
+    fs::create_dir(&empty).expect("empty directory should be created");
+    fs::write(empty.join("notes.txt"), "not Apex").expect("unrelated file should be written");
+    let no_match_output = run_cli(&directory, &["--check", empty.to_str().unwrap()]);
+    assert!(!no_match_output.status.success());
+    assert!(String::from_utf8_lossy(&no_match_output.stderr)
+        .contains("No eligible Apex files were found"));
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn bulk_write_then_check_is_idempotent_and_preserves_files() {
+    let directory = temporary_directory();
+    let class_file = directory.join("Account.cls");
+    let trigger_file = directory.join("Account.trigger");
+    write_fixture(&class_file);
+    write_fixture(&trigger_file);
+
+    let write_output = run_cli(&directory, &["--write", directory.to_str().unwrap()]);
+    assert!(write_output.status.success());
+    let class_bytes = fs::read(&class_file).expect("class output should be readable");
+    let trigger_bytes = fs::read(&trigger_file).expect("trigger output should be readable");
+    let class_time = fs::metadata(&class_file)
+        .expect("class metadata should be readable")
+        .modified()
+        .expect("class timestamp should be available");
+    let trigger_time = fs::metadata(&trigger_file)
+        .expect("trigger metadata should be readable")
+        .modified()
+        .expect("trigger timestamp should be available");
+
+    let check_output = run_cli(&directory, &["--check", directory.to_str().unwrap()]);
+    assert!(check_output.status.success());
+    assert!(String::from_utf8_lossy(&check_output.stderr)
+        .contains("Summary: selected=2, changed=0, written=0, unchanged=2, failed=0"));
+    assert_eq!(
+        fs::read(&class_file).expect("class output should remain readable"),
+        class_bytes
+    );
+    assert_eq!(
+        fs::read(&trigger_file).expect("trigger output should remain readable"),
+        trigger_bytes
+    );
+    assert_eq!(
+        fs::metadata(&class_file)
+            .expect("class metadata should remain readable")
+            .modified()
+            .expect("class timestamp should remain available"),
+        class_time
+    );
+    assert_eq!(
+        fs::metadata(&trigger_file)
+            .expect("trigger metadata should remain readable")
+            .modified()
+            .expect("trigger timestamp should remain available"),
+        trigger_time
+    );
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn time_reports_per_file_and_total_on_stderr() {
+    let directory = temporary_directory();
+    let first = directory.join("a.cls");
+    let second = directory.join("b.cls");
+    write_fixture(&first);
+    write_fixture(&second);
+
+    let output = run_cli(&directory, &["--time", directory.to_str().unwrap()]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(!stdout.contains("Timing:"));
+    assert!(stderr.contains(&format!("Timing: {}", first.display())));
+    assert!(stderr.contains(&format!("Timing: {}", second.display())));
+    assert!(stderr.contains("Total elapsed:"));
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}

--- a/tests/configs/.afmt_configurable_style.toml
+++ b/tests/configs/.afmt_configurable_style.toml
@@ -3,3 +3,4 @@ indent_size = 4
 brace_style = "allman"
 wrap_single_statements = true
 indent_style = "tab"
+normalize_annotation_casing = true

--- a/tests/configs/.afmt_configurable_style.toml
+++ b/tests/configs/.afmt_configurable_style.toml
@@ -3,3 +3,4 @@ indent_size = 4
 brace_style = "allman"
 wrap_single_statements = true
 indent_style = "tab"
+javadoc_star_column = "flush"

--- a/tests/configs/.afmt_configurable_style.toml
+++ b/tests/configs/.afmt_configurable_style.toml
@@ -1,0 +1,5 @@
+max_width = 80
+indent_size = 4
+brace_style = "allman"
+wrap_single_statements = true
+indent_style = "tab"

--- a/tests/configurable_style/annotation_casing.cls
+++ b/tests/configurable_style/annotation_casing.cls
@@ -1,0 +1,24 @@
+@RestResource(urlMapping='/v1/*')
+@IsTest
+global class AnnotationCasing
+{
+	@AuraEnabled
+	public static void run()
+	{
+	}
+
+	@TestSetup
+	static void setup()
+	{
+	}
+
+	@Future
+	static void later()
+	{
+	}
+
+	@MyCustomAnno
+	public static void custom()
+	{
+	}
+}

--- a/tests/configurable_style/annotation_casing.in
+++ b/tests/configurable_style/annotation_casing.in
@@ -1,0 +1,15 @@
+@rEsTrEsOuRcE(urlMapping='/v1/*')
+@iStEsT
+global class AnnotationCasing {
+  @aUrAeNaBlEd
+  public static void run() {}
+
+  @tEsTsEtUp
+  static void setup() {}
+
+  @fUtUrE
+  static void later() {}
+
+  @MyCustomAnno
+  public static void custom() {}
+}

--- a/tests/configurable_style/structural.cls
+++ b/tests/configurable_style/structural.cls
@@ -1,0 +1,109 @@
+class ConfigurableStyle
+{
+	enum Season
+	{
+		WINTER,
+		SPRING
+	}
+
+	public Integer property
+	{
+		get
+		{
+			return property;
+		}
+		set
+		{
+			property = value;
+		}
+	}
+	public Integer autoProperty
+	{ get; set; }
+
+	static
+	{
+		Integer initialized = 1;
+	}
+
+	ConfigurableStyle()
+	{
+		initialized = 2;
+	}
+
+	void run(Integer value)
+	{
+		if (value > 0)
+		{
+			return;
+		}
+		else if (value < 0)
+		{
+			return;
+		}
+		else
+		{
+			return;
+		}
+		for (Integer i = 0; i < value; i++)
+		{
+			System.debug(i);
+		}
+		for (Integer i = 0; i < value; i++)
+		{
+		}
+		for (Account account : accounts)
+		{
+		}
+		while (value > 0)
+		{
+			value--;
+		}
+		while (value > 0)
+		{
+		}
+		do
+		{
+			value--;
+		}
+		while (value > 0);
+		try
+		{
+			System.debug(value);
+		}
+		// Keep clause comments attached while changing the clause separator.
+		catch (Exception e)
+		{
+			System.debug(e);
+		}
+		// The finally clause is also a separate Allman header.
+		finally
+		{
+			System.debug(value);
+		}
+		System.runAs(user)
+		{
+			System.debug(value);
+		}
+		switch on value
+		{
+			when 1
+			{
+				System.debug('one');
+			}
+			when else
+			{
+				System.debug('other');
+			}
+		}
+	}
+}
+
+interface ConfigurableContract
+{
+	void execute();
+}
+
+trigger ConfigurableTrigger on Account(after insert)
+{
+	System.debug(Trigger.new);
+}

--- a/tests/configurable_style/structural.cls
+++ b/tests/configurable_style/structural.cls
@@ -30,6 +30,12 @@ class ConfigurableStyle
 		initialized = 2;
 	}
 
+	/**
+	* Runs the configured operation.
+	*
+	* @param value the input value
+	* @return the result value
+	*/
 	void run(Integer value)
 	{
 		if (value > 0)

--- a/tests/configurable_style/structural.in
+++ b/tests/configurable_style/structural.in
@@ -11,6 +11,11 @@ class ConfigurableStyle {
 
   ConfigurableStyle() { initialized = 2; }
 
+  /** Runs the configured operation.
+   *
+   * @param value the input value
+   * @return the result value
+   */
   void run(Integer value) {
     if (value > 0) return; else if (value < 0) return; else return;
     for (Integer i = 0; i < value; i++) System.debug(i);

--- a/tests/configurable_style/structural.in
+++ b/tests/configurable_style/structural.in
@@ -1,0 +1,38 @@
+class ConfigurableStyle {
+  enum Season {WINTER, SPRING}
+
+  public Integer property {
+    get { return property; }
+    set { property = value; }
+  }
+  public Integer autoProperty { get; set; }
+
+  static { Integer initialized = 1; }
+
+  ConfigurableStyle() { initialized = 2; }
+
+  void run(Integer value) {
+    if (value > 0) return; else if (value < 0) return; else return;
+    for (Integer i = 0; i < value; i++) System.debug(i);
+    for (Integer i = 0; i < value; i++);
+    for (Account account : accounts);
+    while (value > 0) value--;
+    while (value > 0);
+    do { value--; } while (value > 0);
+    try { System.debug(value); }
+    // Keep clause comments attached while changing the clause separator.
+    catch (Exception e) { System.debug(e); }
+    // The finally clause is also a separate Allman header.
+    finally { System.debug(value); }
+    System.runAs(user) { System.debug(value); }
+    switch on value { when 1 { System.debug('one'); } when else { System.debug('other'); } }
+  }
+}
+
+interface ConfigurableContract {
+  void execute();
+}
+
+trigger ConfigurableTrigger on Account (after insert) {
+  System.debug(Trigger.new);
+}

--- a/tests/public_config_api.rs
+++ b/tests/public_config_api.rs
@@ -1,0 +1,15 @@
+use sf_afmt::formatter::{BraceStyle, Config, Formatter, IndentStyle, JavadocStarColumn};
+
+#[test]
+fn public_style_enums_can_configure_the_library() {
+    let config = Config {
+        brace_style: BraceStyle::Allman,
+        indent_style: IndentStyle::Tab,
+        javadoc_star_column: JavadocStarColumn::Flush,
+        ..Config::default()
+    };
+
+    let formatted = Formatter::format_one("class T { }\n", config);
+
+    assert_eq!(formatted, "class T\n{\n}\n");
+}

--- a/tests/static/anonymous_apex.cls
+++ b/tests/static/anonymous_apex.cls
@@ -1,0 +1,7 @@
+Account[] accts = [SELECT Id FROM Account LIMIT 5];
+List<Contact> cons = new List<Contact>();
+for (Account a : accts) {
+  cons.add(new Contact(LastName = 'x', AccountId = a.Id));
+}
+insert cons;
+System.debug('done');

--- a/tests/static/anonymous_apex.in
+++ b/tests/static/anonymous_apex.in
@@ -1,0 +1,7 @@
+Account[] accts = [SELECT Id FROM Account LIMIT 5];
+List<Contact> cons = new List<Contact>();
+for (Account a : accts) {
+cons.add(new Contact(LastName = 'x', AccountId = a.Id));
+}
+insert cons;
+System.debug('done');

--- a/tests/static/comment_method_chain.cls
+++ b/tests/static/comment_method_chain.cls
@@ -1,0 +1,12 @@
+public class CommentMethodChain {
+  public static void run() {
+    Builder b =
+      new LogEntryEventBuilder(
+        getUserSettings(),
+        loggingLevel,
+        shouldSaveThisEntryValue
+      )
+      // Don't include the logging system's classes in the stack trace
+      .parseStackTrace(new System.DmlException().getStackTraceString());
+  }
+}

--- a/tests/static/comment_method_chain.in
+++ b/tests/static/comment_method_chain.in
@@ -1,0 +1,7 @@
+public class CommentMethodChain {
+  public static void run() {
+    Builder b = new LogEntryEventBuilder(getUserSettings(), loggingLevel, shouldSaveThisEntryValue)
+      // Don't include the logging system's classes in the stack trace
+      .parseStackTrace(new System.DmlException().getStackTraceString());
+  }
+}

--- a/tests/static/comment_method_chain_mixed_block_line.cls
+++ b/tests/static/comment_method_chain_mixed_block_line.cls
@@ -1,0 +1,8 @@
+public class CommentMethodChainMixedBlockLine {
+  public static void run() {
+    Builder b = new Builder()
+      /* block before line */
+      // line before method
+      .build();
+  }
+}

--- a/tests/static/comment_method_chain_mixed_block_line.in
+++ b/tests/static/comment_method_chain_mixed_block_line.in
@@ -1,0 +1,8 @@
+public class CommentMethodChainMixedBlockLine {
+  public static void run() {
+    Builder b = new Builder()
+      /* block before line */
+      // line before method
+      .build();
+  }
+}

--- a/tests/static/comment_method_chain_mixed_line_block.cls
+++ b/tests/static/comment_method_chain_mixed_line_block.cls
@@ -1,0 +1,8 @@
+public class CommentMethodChainMixedLineBlock {
+  public static void run() {
+    Builder b = new Builder()
+      // line before block
+      /* block before method */
+      .build();
+  }
+}

--- a/tests/static/comment_method_chain_mixed_line_block.in
+++ b/tests/static/comment_method_chain_mixed_line_block.in
@@ -1,0 +1,8 @@
+public class CommentMethodChainMixedLineBlock {
+  public static void run() {
+    Builder b = new Builder()
+      // line before block
+      /* block before method */
+      .build();
+  }
+}

--- a/tests/static/comment_unbraced_else.cls
+++ b/tests/static/comment_unbraced_else.cls
@@ -1,0 +1,10 @@
+public class CommentUnbracedElse {
+  public static void run(Integer symbol) {
+    if (symbol == 16)
+      symbol = 2;
+    else if (symbol == 17) /* repeat zero 3..10 times */
+      symbol = 3 + bits(symbol, 3);
+    else /* == 18, repeat zero 11..138 times */
+      symbol = 11 + bits(symbol, 7);
+  }
+}

--- a/tests/static/comment_unbraced_else.in
+++ b/tests/static/comment_unbraced_else.in
@@ -1,0 +1,10 @@
+public class CommentUnbracedElse {
+  public static void run(Integer symbol) {
+    if (symbol == 16)
+      symbol = 2;
+    else if (symbol == 17) /* repeat zero 3..10 times */
+      symbol = 3 + bits(symbol, 3);
+    else /* == 18, repeat zero 11..138 times */
+      symbol = 11 + bits(symbol, 7);
+  }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -27,6 +27,12 @@ mod tests {
     }
 
     #[test]
+    fn configurable_style() {
+        let (total, failed) = run_scenario("tests/configurable_style", "configurable_style");
+        assert_eq!(failed, 0, "{} out of {} tests failed", failed, total);
+    }
+
+    #[test]
     fn all() {
         let scenarios = [
             ("tests/static", "static"),
@@ -93,6 +99,7 @@ mod tests {
             "static" => run_static_test_files(source),
             "prettier80" => run_prettier_test_files(source, "p80"),
             "comments" => run_static_test_files(source),
+            "configurable_style" => run_configurable_style_test_files(source),
             _ => panic!("Unknown scenario: {}", scenario_name),
         });
 
@@ -121,6 +128,19 @@ mod tests {
         });
 
         compare("Static:", output, expected, source)
+    }
+
+    fn run_configurable_style_test_files(source: &Path) -> bool {
+        let expected_file = source.with_extension("cls");
+        let output = format_with_afmt(source, Some("tests/configs/.afmt_configurable_style.toml"));
+        let expected = std::fs::read_to_string(&expected_file).unwrap_or_else(|_| {
+            panic!(
+                "Failed to read expected .cls file at {}",
+                red(&expected_file.to_string_lossy())
+            )
+        });
+
+        compare("Configurable style:", output, expected, source)
     }
 
     fn run_prettier_test_files(source: &Path, config_name: &str) -> bool {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,6 +7,7 @@ mod tests {
     use std::io::Write;
     use std::path::Path;
     use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn statics() {
@@ -24,6 +25,29 @@ mod tests {
     fn comments() {
         let (total, failed) = run_scenario("tests/comments", "comments");
         assert_eq!(failed, 0, "{} out of {} tests failed", failed, total);
+    }
+
+    #[test]
+    fn idempotency_static() {
+        run_idempotency("tests/static", "static", "tests/configs/.afmt_static.toml");
+    }
+
+    #[test]
+    fn idempotency_prettier80() {
+        run_idempotency(
+            "tests/prettier80",
+            "prettier80",
+            "tests/configs/.afmt_p80.toml",
+        );
+    }
+
+    #[test]
+    fn idempotency_comments() {
+        run_idempotency(
+            "tests/comments",
+            "comments",
+            "tests/configs/.afmt_static.toml",
+        );
     }
 
     #[test]
@@ -85,6 +109,59 @@ mod tests {
             total_tests
         );
         (total_tests, failed_tests)
+    }
+
+    fn run_idempotency(dir_path: &str, scenario_name: &str, config_path: &str) {
+        let mut sources = std::fs::read_dir(dir_path)
+            .expect("idempotency fixture directory should be readable")
+            .map(|entry| entry.expect("fixture entry should be readable").path())
+            .filter(|path| path.extension().and_then(|extension| extension.to_str()) == Some("in"))
+            .collect::<Vec<_>>();
+        sources.sort();
+
+        for source in sources {
+            let run_id = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after the Unix epoch")
+                .as_nanos();
+            let first_path = std::env::temp_dir().join(format!(
+                "sf-afmt-idempotency-{}-{}-{}-first.cls",
+                std::process::id(),
+                scenario_name,
+                run_id
+            ));
+            let second_path = first_path.with_file_name(format!(
+                "sf-afmt-idempotency-{}-{}-{}-second.cls",
+                std::process::id(),
+                scenario_name,
+                run_id
+            ));
+
+            let first = format_with_afmt(&source, Some(config_path));
+            std::fs::write(&first_path, &first).expect("first formatted output should be written");
+            let second = format_with_afmt(&first_path, Some(config_path));
+            std::fs::write(&second_path, &second)
+                .expect("second formatted output should be written");
+
+            let first_bytes = std::fs::read(&first_path).expect("first output should be readable");
+            let second_bytes =
+                std::fs::read(&second_path).expect("second output should be readable");
+            if first_bytes != second_bytes {
+                let diff = TextDiff::from_lines(&first, &second)
+                    .unified_diff()
+                    .header("first pass", "second pass")
+                    .to_string();
+                panic!(
+                    "{} fixture is not idempotent: {}\n{}",
+                    scenario_name,
+                    source.display(),
+                    diff
+                );
+            }
+
+            std::fs::remove_file(first_path).expect("first temporary output should be removed");
+            std::fs::remove_file(second_path).expect("second temporary output should be removed");
+        }
     }
 
     fn run_test_file(source: &Path, scenario_name: &str) -> bool {
@@ -152,6 +229,8 @@ mod tests {
     fn normalize(content: &str) -> String {
         //println!("{} (Hex):", label);
         let mut normalized = String::new();
+        // Git may check out fixtures as CRLF on Windows, while the formatter emits LF.
+        let content = content.replace("\r\n", "\n");
 
         for (i, byte) in content.bytes().enumerate() {
             if i % 16 == 0 && i != 0 {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -15,6 +15,25 @@ mod tests {
     }
 
     #[test]
+    fn idempotency_static() {
+        let config = Config::from_file("tests/configs/.afmt_static.toml")
+            .expect("failed to load static test config");
+
+        for source_path in [
+            "tests/static/comment_method_chain.in",
+            "tests/static/comment_method_chain_mixed_block_line.in",
+            "tests/static/comment_method_chain_mixed_line_block.in",
+            "tests/static/comment_unbraced_else.in",
+        ] {
+            let input = std::fs::read_to_string(source_path).expect("failed to read fixture");
+            let first = format_source(&input, &config);
+            let second = format_source(&first, &config);
+
+            assert_eq!(first, second, "{} is not idempotent", source_path);
+        }
+    }
+
+    #[test]
     fn prettier80() {
         let (total, failed) = run_scenario("tests/prettier80", "prettier80");
         assert_eq!(failed, 0, "{} out of {} tests failed", failed, total);
@@ -202,6 +221,14 @@ mod tests {
             .next()
             .and_then(|result| result.ok())
             .expect("format result failed.")
+    }
+
+    fn format_source(source: &str, config: &Config) -> String {
+        let source = source.to_owned();
+        let config = config.clone();
+        std::thread::spawn(move || Formatter::format_one(&source, config))
+            .join()
+            .expect("format thread panicked")
     }
 
     fn print_side_by_side_diff(against: &str, output: &str, expected: &str) {


### PR DESCRIPTION
## Summary

- Document `normalize_annotation_casing = false` in the integrated formatter configuration guide.
- Describe the default, canonical known-name examples, verbatim unknown names, and name-only scope.
- Keep the README as-is because its existing documentation is already consistent.

## Validation

- `cargo test formatter::tests` — 27 passed
- `cargo test --all-features` — 63 passed
- `git diff --check` — passed

## Work item

`afmt-annotation-casing-configuration-guide-alignment.md`

The local canonical `main` reference predates the sibling integration changes, so this branch was created from the combined integration base containing those changes. Once that work is present on `main`, this PR reduces to the documentation commit shown here; no formatter behavior changes are included.