### PR TITLE
refactor(afmt): separate source formatter from batch adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,12 @@ focused project documentation below.
 
 - Formatter configuration and style behavior:
   [docs/configuration.md](docs/configuration.md)
+- Formatter source-core and file/batch-adapter boundaries:
+  [docs/formatter-architecture.md](docs/formatter-architecture.md)
 - Comment placement and formatter idempotency:
   [docs/comment-placement-and-idempotency.md](docs/comment-placement-and-idempotency.md)
+- Name-path chain formatting:
+  [docs/name-path-chain-formatting.md](docs/name-path-chain-formatting.md)
 - User-facing bulk formatting, configuration, discovery, and CLI semantics:
   [docs/project-wide-formatting.md](docs/project-wide-formatting.md)
 - Test, battle-corpus, and local benchmark workflow:

--- a/docs/formatter-architecture.md
+++ b/docs/formatter-architecture.md
@@ -1,0 +1,49 @@
+# Formatter architecture
+
+`afmt` keeps source-to-source formatting separate from file and batch
+adaptation. The split is internal, but the existing public `formatter` module
+continues to provide the 1.x API surface.
+
+## Source formatting core
+
+`src/source_formatter.rs` owns the source-only pipeline:
+
+- `Config` data, defaults, and formatter-option validation.
+- Apex parsing, comment enrichment, formatting-session construction, and
+  pretty-printing.
+- Source-formatting error and panic isolation for `try_format_source`.
+
+The core accepts source text and a formatter configuration. It does not read or
+write files, construct path-aware errors, measure elapsed time, or invoke
+Rayon. Direct source-core tests live beside this module and do not need a
+filesystem fixture.
+
+## File and batch adapter
+
+`src/formatter.rs` is the public compatibility facade and file/batch adapter.
+It owns:
+
+- `Formatter` construction from source paths and configuration files.
+- File reads and `FormattedFile` change detection.
+- `FormatFileError` path decoration and `FormatOutcome` timing.
+- Rayon-based batch execution while preserving input ordering.
+
+Source-formatting failures are returned by the core first; the adapter adds a
+path only when it creates a `FormatFileError`. `formatter::Config` and the
+existing `Formatter` methods remain available to 1.x consumers through
+re-exports and thin forwarding methods. `Config::from_file` remains an
+adapter-side compatibility method because it performs filesystem I/O; TOML
+loading for project-wide selection is handled by `src/config.rs`.
+
+## Other boundaries
+
+- `src/config.rs` owns application-level TOML loading and file-selection
+  defaults.
+- `src/discovery.rs` owns path expansion, glob matching, exclusions,
+  de-duplication, and ordering.
+- `src/main.rs` owns CLI selection, output, check/write policy, timing display,
+  and aggregate status.
+
+Keep future source-formatting changes in the source core when they only need a
+buffer and `Config`. Keep filesystem, path, timing, and batch concerns at the
+adapter or CLI boundaries.

--- a/docs/project-wide-formatting.md
+++ b/docs/project-wide-formatting.md
@@ -99,8 +99,12 @@ both:
 
 ## Implementation boundaries
 
-`src/config.rs` owns application-level TOML loading and file-selection
-defaults. `src/discovery.rs` owns path expansion, glob matching, exclusions,
-de-duplication, and ordering. `src/formatter.rs` owns formatting and
-path-aware per-file outcomes. `src/main.rs` owns CLI output, check/write
-policy, timing, and aggregate status.
+`src/source_formatter.rs` owns the source-to-source formatting core and
+formatter configuration validation. `src/formatter.rs` provides the public
+1.x compatibility surface and owns file reads, path-aware per-file outcomes,
+elapsed timing, and Rayon batch execution. `src/config.rs` owns
+application-level TOML loading and file-selection defaults. `src/discovery.rs`
+owns path expansion, glob matching, exclusions, de-duplication, and ordering.
+`src/main.rs` owns CLI output, check/write policy, timing display, and aggregate
+status. See [Formatter architecture](formatter-architecture.md) for the
+boundary details.

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,92 +1,20 @@
-use crate::data_model::*;
-use crate::doc::{pretty_print, PrettyConfig};
-use crate::doc_builder::DocBuilder;
-use crate::formatting_session::FormattingSession;
-use crate::message_helper::{red, yellow};
-use crate::utility::{assert_no_missing_comments, enrich, truncate_snippet};
+use crate::message_helper::yellow;
+use crate::source_formatter;
 use rayon::prelude::*;
-use serde::Deserialize;
 use std::{
     fs,
-    panic::{catch_unwind, AssertUnwindSafe},
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
-use tree_sitter::{Node, Parser, Tree};
 
 pub use crate::doc::{BraceStyle, IndentStyle, JavadocStarColumn};
+pub use crate::source_formatter::Config;
+use tree_sitter::Tree;
 
 #[allow(unused_imports)]
 use crate::utility::print_comment_map;
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct Config {
-    #[serde(default = "default_max_width")]
-    pub max_width: u32,
-
-    #[serde(default = "default_indent_size")]
-    pub indent_size: u32,
-
-    /// Opening-brace placement. Default `k_and_r` preserves current output.
-    #[serde(default)]
-    pub brace_style: BraceStyle,
-
-    /// Wrap single-statement `if`/`else`/loop bodies in braces. Default `false`.
-    #[serde(default)]
-    pub wrap_single_statements: bool,
-
-    /// Indentation character. Default `space`.
-    #[serde(default)]
-    pub indent_style: IndentStyle,
-
-    /// JavaDoc continuation-star placement. Default `offset` preserves output.
-    #[serde(default)]
-    pub javadoc_star_column: JavadocStarColumn,
-
-    /// Normalize known Apex annotation names to Salesforce's canonical casing.
-    /// Default `false` preserves source casing.
-    #[serde(default)]
-    pub normalize_annotation_casing: bool,
-}
-
-fn default_max_width() -> u32 {
-    80
-}
-
-fn default_indent_size() -> u32 {
-    2
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            max_width: default_max_width(),
-            indent_size: default_indent_size(),
-            brace_style: BraceStyle::default(),
-            wrap_single_statements: false,
-            indent_style: IndentStyle::default(),
-            javadoc_star_column: JavadocStarColumn::default(),
-            normalize_annotation_casing: false,
-        }
-    }
-}
-
 impl Config {
-    pub fn new(max_width: u32) -> Self {
-        Self {
-            max_width,
-            ..Config::default()
-        }
-    }
-
-    pub fn validate(&self) -> Result<(), String> {
-        if self.indent_size == 0 {
-            return Err("indent_size must be at least 1".to_string());
-        }
-
-        Ok(())
-    }
-
     pub fn from_file(path: &str) -> Result<Self, String> {
         let content =
             fs::read_to_string(path).map_err(|e| format!("Failed to read config file: {}", e))?;
@@ -96,14 +24,6 @@ impl Config {
             .validate()
             .map_err(|error| format!("Invalid formatter configuration: {error}"))?;
         Ok(config)
-    }
-
-    pub fn max_width(&self) -> u32 {
-        self.max_width
-    }
-
-    pub fn indent_size(&self) -> u32 {
-        self.indent_size
     }
 }
 
@@ -231,127 +151,15 @@ impl Formatter {
     }
 
     pub fn format_one(source_code: &str, config: Config) -> String {
-        Self::try_format_source(source_code, config).unwrap_or_else(|message| panic!("{}", message))
+        source_formatter::format_one(source_code, config)
     }
 
     pub fn try_format_source(source_code: &str, config: Config) -> Result<String, String> {
-        match catch_unwind(AssertUnwindSafe(|| {
-            Self::try_format_source_unchecked(source_code, config)
-        })) {
-            Ok(result) => result,
-            Err(panic_payload) => Err(format!(
-                "Formatting panicked: {}",
-                panic_message(panic_payload)
-            )),
-        }
-    }
-
-    fn try_format_source_unchecked(source_code: &str, config: Config) -> Result<String, String> {
-        config
-            .validate()
-            .map_err(|error| format!("Invalid formatter configuration: {error}"))?;
-
-        let ast_tree = Self::try_parse(source_code)?;
-        let _session = FormattingSession::new(source_code, &ast_tree);
-
-        // traverse the tree to build enriched data
-        let root: Root = enrich(&ast_tree);
-
-        // traverse enriched data and create pretty print combinators
-        let c = PrettyConfig::new(
-            config.indent_size,
-            config.brace_style,
-            config.wrap_single_statements,
-            config.indent_style,
-            config.javadoc_star_column,
-            config.normalize_annotation_casing,
-        );
-        let b = DocBuilder::new(c);
-        let doc_ref = root.build(&b);
-
-        let result = pretty_print(doc_ref, config.max_width, c);
-
-        // debugging tool: use this to print named node value + comments in bucket
-        // print_comment_map(&ast_tree);
-
-        assert_no_missing_comments();
-
-        Ok(result)
+        source_formatter::try_format_source(source_code, config)
     }
 
     pub fn parse(source_code: &str) -> Tree {
-        Self::try_parse(source_code).unwrap_or_else(|message| panic!("{}", message))
-    }
-
-    fn try_parse(source_code: &str) -> Result<Tree, String> {
-        let mut parser = Parser::new();
-        let language_fn = tree_sitter_sfapex::apex::LANGUAGE;
-        parser
-            .set_language(&language_fn.into())
-            .expect("Error loading Apex parser");
-
-        let ast_tree = parser.parse(source_code, None).unwrap();
-        let root_node = &ast_tree.root_node();
-
-        if root_node.has_error() {
-            if let Some(error_node) = Self::find_last_error_node(root_node) {
-                let error_snippet =
-                    truncate_snippet(&source_code[error_node.start_byte()..error_node.end_byte()]);
-                let mut diagnostic = format!(
-                    "Error in node kind: {}, at byte range: {}-{}, snippet: {}",
-                    yellow(error_node.kind()),
-                    error_node.start_byte(),
-                    error_node.end_byte(),
-                    error_snippet,
-                );
-                if let Some(p) = error_node.parent() {
-                    let parent_snippet =
-                        truncate_snippet(&source_code[p.start_byte()..p.end_byte()]);
-                    diagnostic.push_str(&format!(
-                        "\nParent node kind: {}, at byte range: {}-{}, snippet: {}",
-                        yellow(p.kind()),
-                        p.start_byte(),
-                        p.end_byte(),
-                        parent_snippet,
-                    ));
-                }
-                return Err(format!(
-                    "{}\n{}",
-                    diagnostic,
-                    red("Parser encounters an error node in the tree.")
-                ));
-            }
-        }
-
-        Ok(ast_tree)
-    }
-
-    fn find_last_error_node<'tree>(node: &Node<'tree>) -> Option<Node<'tree>> {
-        if !node.has_error() {
-            return None; // If the current node has no error, return None
-        }
-
-        let mut last_error_node = Some(*node);
-
-        for i in 0..node.child_count() {
-            if let Some(child) = node.child(i) {
-                if child.has_error() {
-                    last_error_node = Self::find_last_error_node(&child);
-                }
-            }
-        }
-
-        last_error_node // Return the last (deepest) error node
-    }
-}
-
-fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
-    if let Some(message) = payload.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else if let Some(message) = payload.downcast_ref::<String>() {
-        message.clone()
-    } else {
-        "unknown panic payload".to_string()
+        source_formatter::parse(source_code)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod enum_def;
 pub mod formatter;
 mod formatting_session;
 pub mod message_helper;
+mod source_formatter;
 mod utility;
 use formatter::Formatter;
 

--- a/src/source_formatter.rs
+++ b/src/source_formatter.rs
@@ -1,0 +1,260 @@
+use crate::data_model::*;
+use crate::doc::{pretty_print, BraceStyle, IndentStyle, JavadocStarColumn, PrettyConfig};
+use crate::doc_builder::DocBuilder;
+use crate::formatting_session::FormattingSession;
+use crate::message_helper::{red, yellow};
+use crate::utility::{assert_no_missing_comments, enrich, truncate_snippet};
+use serde::Deserialize;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use tree_sitter::{Node, Parser, Tree};
+
+/// Source-only formatter configuration and formatting pipeline.
+#[derive(Clone, Debug, Deserialize)]
+pub struct Config {
+    #[serde(default = "default_max_width")]
+    pub max_width: u32,
+
+    #[serde(default = "default_indent_size")]
+    pub indent_size: u32,
+
+    /// Opening-brace placement. Default `k_and_r` preserves current output.
+    #[serde(default)]
+    pub brace_style: BraceStyle,
+
+    /// Wrap single-statement `if`/`else`/loop bodies in braces. Default `false`.
+    #[serde(default)]
+    pub wrap_single_statements: bool,
+
+    /// Indentation character. Default `space`.
+    #[serde(default)]
+    pub indent_style: IndentStyle,
+
+    /// JavaDoc continuation-star placement. Default `offset` preserves output.
+    #[serde(default)]
+    pub javadoc_star_column: JavadocStarColumn,
+
+    /// Normalize known Apex annotation names to Salesforce's canonical casing.
+    /// Default `false` preserves source casing.
+    #[serde(default)]
+    pub normalize_annotation_casing: bool,
+}
+
+fn default_max_width() -> u32 {
+    80
+}
+
+fn default_indent_size() -> u32 {
+    2
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            max_width: default_max_width(),
+            indent_size: default_indent_size(),
+            brace_style: BraceStyle::default(),
+            wrap_single_statements: false,
+            indent_style: IndentStyle::default(),
+            javadoc_star_column: JavadocStarColumn::default(),
+            normalize_annotation_casing: false,
+        }
+    }
+}
+
+impl Config {
+    pub fn new(max_width: u32) -> Self {
+        Self {
+            max_width,
+            ..Config::default()
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.indent_size == 0 {
+            return Err("indent_size must be at least 1".to_string());
+        }
+
+        Ok(())
+    }
+
+    pub fn max_width(&self) -> u32 {
+        self.max_width
+    }
+
+    pub fn indent_size(&self) -> u32 {
+        self.indent_size
+    }
+}
+
+pub(crate) fn format_one(source_code: &str, config: Config) -> String {
+    try_format_source(source_code, config).unwrap_or_else(|message| panic!("{}", message))
+}
+
+pub(crate) fn try_format_source(source_code: &str, config: Config) -> Result<String, String> {
+    match catch_unwind(AssertUnwindSafe(|| {
+        try_format_source_unchecked(source_code, config)
+    })) {
+        Ok(result) => result,
+        Err(panic_payload) => Err(format!(
+            "Formatting panicked: {}",
+            panic_message(panic_payload)
+        )),
+    }
+}
+
+fn try_format_source_unchecked(source_code: &str, config: Config) -> Result<String, String> {
+    config
+        .validate()
+        .map_err(|error| format!("Invalid formatter configuration: {error}"))?;
+
+    let ast_tree = try_parse(source_code)?;
+    let _session = FormattingSession::new(source_code, &ast_tree);
+
+    // traverse the tree to build enriched data
+    let root: Root = enrich(&ast_tree);
+
+    // traverse enriched data and create pretty print combinators
+    let c = PrettyConfig::new(
+        config.indent_size,
+        config.brace_style,
+        config.wrap_single_statements,
+        config.indent_style,
+        config.javadoc_star_column,
+        config.normalize_annotation_casing,
+    );
+    let b = DocBuilder::new(c);
+    let doc_ref = root.build(&b);
+
+    let result = pretty_print(doc_ref, config.max_width, c);
+
+    // debugging tool: use this to print named node value + comments in bucket
+    // print_comment_map(&ast_tree);
+
+    assert_no_missing_comments();
+
+    Ok(result)
+}
+
+pub(crate) fn parse(source_code: &str) -> Tree {
+    try_parse(source_code).unwrap_or_else(|message| panic!("{}", message))
+}
+
+fn try_parse(source_code: &str) -> Result<Tree, String> {
+    let mut parser = Parser::new();
+    let language_fn = tree_sitter_sfapex::apex::LANGUAGE;
+    parser
+        .set_language(&language_fn.into())
+        .expect("Error loading Apex parser");
+
+    let ast_tree = parser.parse(source_code, None).unwrap();
+    let root_node = &ast_tree.root_node();
+
+    if root_node.has_error() {
+        if let Some(error_node) = find_last_error_node(root_node) {
+            let error_snippet =
+                truncate_snippet(&source_code[error_node.start_byte()..error_node.end_byte()]);
+            let mut diagnostic = format!(
+                "Error in node kind: {}, at byte range: {}-{}, snippet: {}",
+                yellow(error_node.kind()),
+                error_node.start_byte(),
+                error_node.end_byte(),
+                error_snippet,
+            );
+            if let Some(p) = error_node.parent() {
+                let parent_snippet = truncate_snippet(&source_code[p.start_byte()..p.end_byte()]);
+                diagnostic.push_str(&format!(
+                    "\nParent node kind: {}, at byte range: {}-{}, snippet: {}",
+                    yellow(p.kind()),
+                    p.start_byte(),
+                    p.end_byte(),
+                    parent_snippet,
+                ));
+            }
+            return Err(format!(
+                "{}\n{}",
+                diagnostic,
+                red("Parser encounters an error node in the tree."),
+            ));
+        }
+    }
+
+    Ok(ast_tree)
+}
+
+fn find_last_error_node<'tree>(node: &Node<'tree>) -> Option<Node<'tree>> {
+    if !node.has_error() {
+        return None; // If the current node has no error, return None
+    }
+
+    let mut last_error_node = Some(*node);
+
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if child.has_error() {
+                last_error_node = find_last_error_node(&child);
+            }
+        }
+    }
+
+    last_error_node // Return the last (deepest) error node
+}
+
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{try_format_source, Config};
+
+    const VALID_SOURCE: &str = "class T { void m() {} }\n";
+
+    #[test]
+    fn source_core_formats_valid_source_without_file_setup() {
+        let formatted = try_format_source(VALID_SOURCE, Config::default()).expect("source formats");
+
+        assert!(formatted.contains("class T"));
+        assert!(formatted.contains("void m()"));
+    }
+
+    #[test]
+    fn source_core_reports_parse_failures_without_path_decoration() {
+        let error = try_format_source("class Broken {", Config::default())
+            .expect_err("invalid source should fail");
+
+        assert!(error.contains("Parser encounters an error node"));
+        assert!(!error.contains(".cls:"));
+    }
+
+    #[test]
+    fn source_core_reports_config_validation_errors() {
+        let error = try_format_source(
+            VALID_SOURCE,
+            Config {
+                indent_size: 0,
+                ..Config::default()
+            },
+        )
+        .expect_err("invalid configuration should fail");
+
+        assert_eq!(
+            error,
+            "Invalid formatter configuration: indent_size must be at least 1"
+        );
+    }
+
+    #[test]
+    fn source_core_formatting_is_idempotent() {
+        let first = try_format_source(VALID_SOURCE, Config::default()).expect("source formats");
+        let second =
+            try_format_source(&first, Config::default()).expect("formatted source formats");
+
+        assert_eq!(first, second);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the source-only parsing and formatting pipeline into a private `source_formatter` module while keeping `formatter` as the 1.x compatibility facade for file reads, path-aware errors, timing, and ordered Rayon batch execution. This preserves current formatter behavior while establishing the architecture boundary needed to separate source formatting from filesystem and batch concerns.

Depends on #137

Closes #134

## Implementation notes

- Core source formatting remains independent of filesystem reads, `PathBuf`, timing, and Rayon.
- The adapter owns file reads, per-file result construction, path-decorated errors, timing, and parallel iteration.
- Public symbols, signatures, output, error text, and CLI behavior remain unchanged.
- No public API impact; not gated on a release.

## Testing

- Direct source-formatting and adapter tests cover output, parse and configuration failures, idempotency, path association, timing, ordering, per-file failure isolation, and parallel behavior.
- Comment and idempotency fixtures remain byte-identical.
- Validation: 92 tests, rustfmt check, and Clippy with `-D warnings` passed.

## Out of scope

- Public API removal, typed public errors, or public API surface reduction.
- Comment placement, formatting output, or parser diagnostic changes.
- Removing thread-local storage or threading explicit context through the formatter.
- Moving CLI policy into the library.