### PR TITLE
feat: add afmt ignore directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,13 @@ and contributor validation workflow, see
 
 ### Ignoring a node
 
-Place `// afmt:ignore` immediately before a statement or declaration to keep
-that node's original source formatting while the rest of the file is formatted
-normally. The directive is consumed and is not included in the output.
+Place `// afmt:ignore` as the last pre-comment for a node (such as a statement
+or declaration) to preserve that node's original source bytes, including its
+internal whitespace and blank lines, while the rest of the file is formatted
+normally. The directive is consumed and is not included in the output. Because
+the marker is consumed, deliberately non-canonical ignored source may be
+reformatted on a later invocation; see the [comment placement and idempotency
+guide](docs/comment-placement-and-idempotency.md) for the exact behavior.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Integer[] matrix = new Integer[]{ 1, 0, 0,
 `//afmt:ignore` and `/* afmt:ignore */` work too, and the marker may carry a
 free-text reason, as in `// afmt:ignore column alignment is meaningful here`. A
 marker between annotations and a declaration applies to the complete
-declaration.
+declaration, whether or not that declaration has an access modifier.
 
 The marker stays in the output, so an ignored node stays ignored on every later
 run and `afmt --check` passes on a file that `afmt --write` produced. Multiline
@@ -271,7 +271,13 @@ preserved source keeps its authored interior indentation and forces surrounding
 layout to break; afmt does not re-anchor its interior lines.
 
 If a recognized marker has no eligible following node, afmt preserves it and
-writes a warning to stderr. See the [comment placement and idempotency
+writes a warning to stderr naming the marker's position:
+
+```
+Warning: force-app/main/default/classes/Example.cls:12:5: afmt:ignore could not be applied; directive was preserved
+```
+
+See the [comment placement and idempotency
 guide](docs/comment-placement-and-idempotency.md) for the exact behavior.
 
 <br>

--- a/README.md
+++ b/README.md
@@ -249,12 +249,18 @@ and contributor validation workflow, see
 
 ### Ignoring a node
 
-Place `// afmt:ignore` as the last pre-comment for a node (such as a statement
-or declaration) to preserve that node's original source bytes, including its
-internal whitespace and blank lines, while the rest of the file is formatted
-normally. The directive is consumed and is not included in the output. Because
-the marker is consumed, deliberately non-canonical ignored source may be
-reformatted on a later invocation; see the [comment placement and idempotency
+Place `// afmt:ignore`, `//afmt:ignore`, or `/* afmt:ignore */` as the last
+standalone pre-comment for a node (such as a statement or declaration) to
+preserve that node's original source bytes, including internal whitespace and
+blank lines. A marker between annotations and a declaration applies to the
+complete declaration. The directive is consumed and omitted from the output.
+Multiline preserved source keeps its authored interior indentation and forces
+surrounding layout to break; afmt does not re-anchor its interior lines.
+
+If a recognized marker has no eligible following node, afmt preserves it and
+writes a warning to stderr. Because an honored marker is consumed,
+deliberately non-canonical ignored source may be reformatted on a later
+invocation; see the [comment placement and idempotency
 guide](docs/comment-placement-and-idempotency.md) for the exact behavior.
 
 <br>

--- a/README.md
+++ b/README.md
@@ -249,18 +249,29 @@ and contributor validation workflow, see
 
 ### Ignoring a node
 
-Place `// afmt:ignore`, `//afmt:ignore`, or `/* afmt:ignore */` as the last
-standalone pre-comment for a node (such as a statement or declaration) to
-preserve that node's original source bytes, including internal whitespace and
-blank lines. A marker between annotations and a declaration applies to the
-complete declaration. The directive is consumed and omitted from the output.
-Multiline preserved source keeps its authored interior indentation and forces
-surrounding layout to break; afmt does not re-anchor its interior lines.
+Place `// afmt:ignore` as the last standalone pre-comment for a node (such as a
+statement or declaration) to preserve that node's original source bytes,
+including internal whitespace and blank lines:
+
+```apex
+// afmt:ignore
+Integer[] matrix = new Integer[]{ 1, 0, 0,
+                                  0, 1, 0,
+                                  0, 0, 1 };
+```
+
+`//afmt:ignore` and `/* afmt:ignore */` work too, and the marker may carry a
+free-text reason, as in `// afmt:ignore column alignment is meaningful here`. A
+marker between annotations and a declaration applies to the complete
+declaration.
+
+The marker stays in the output, so an ignored node stays ignored on every later
+run and `afmt --check` passes on a file that `afmt --write` produced. Multiline
+preserved source keeps its authored interior indentation and forces surrounding
+layout to break; afmt does not re-anchor its interior lines.
 
 If a recognized marker has no eligible following node, afmt preserves it and
-writes a warning to stderr. Because an honored marker is consumed,
-deliberately non-canonical ignored source may be reformatted on a later
-invocation; see the [comment placement and idempotency
+writes a warning to stderr. See the [comment placement and idempotency
 guide](docs/comment-placement-and-idempotency.md) for the exact behavior.
 
 <br>

--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ and contributor validation workflow, see
 [the project-wide formatting guide](docs/project-wide-formatting.md) and
 [the validation and benchmark guide](docs/validation-and-benchmarks.md).
 
+### Ignoring a node
+
+Place `// afmt:ignore` immediately before a statement or declaration to keep
+that node's original source formatting while the rest of the file is formatted
+normally. The directive is consumed and is not included in the output.
+
 <br>
 
 ## ❓ FAQ

--- a/docs/comment-placement-and-idempotency.md
+++ b/docs/comment-placement-and-idempotency.md
@@ -32,14 +32,24 @@ styles.
 
 ## Ignored nodes
 
-`// afmt:ignore` is consumed when it is the last pre-comment for a node. The
-node's original source bytes are emitted unchanged, including internal blank
-lines, while the marker itself is omitted from the output. This is an
-intentional escape hatch from normal formatting, so a deliberately
-non-canonical ignored node can be reformatted on a later invocation: once the
-marker has been consumed, a new formatting run has no way to identify that
-node. The idempotency guarantee applies when the preserved bytes are already
-stable, as covered by `idempotency_ignore_directive_stable_output`.
+`// afmt:ignore`, `//afmt:ignore`, and `/* afmt:ignore */` are recognized when
+they are the last standalone pre-comment for a node. The node's original
+source bytes are emitted unchanged, including internal blank lines, while the
+marker itself is omitted from the output. A marker between annotations and a
+declaration applies to the complete declaration, rather than to its first
+modifier.
+
+Multiline preserved source forces its surrounding groups to break so width
+accounting remains correct. Its interior indentation is raw source and is not
+re-anchored to the formatter's current indentation level.
+
+If a recognized marker has no eligible following node, afmt retains the marker
+and emits a warning on stderr. This is an intentional escape hatch from normal
+formatting, so a deliberately non-canonical ignored node can be reformatted on
+a later invocation: once an honored marker has been consumed, a new formatting
+run has no way to identify that node. The idempotency guarantee applies when
+the preserved bytes are already stable, as covered by
+`idempotency_ignore_directive_stable_output`.
 
 ## Implementation boundaries
 
@@ -60,9 +70,10 @@ The static fixtures under `tests/static/` cover the method-chain and unbraced
 `tests/configs/.afmt_static.toml` configuration.
 
 The ignore directive fixtures under `tests/ignore/` cover verbatim preservation
-of a deliberately non-canonical node, internal blank lines, surrounding normal
-formatting, and stable marker-bearing output. The `ignore` scenario and
-`idempotency_ignore_directive_stable_output` test exercise that coverage.
+of deliberately non-canonical nodes, internal blank lines, multiline layout,
+inner punctuation, annotation and loop targeting, and recognized marker
+spellings. The `ignore` scenario, `ignored_inner_punctuation_is_idempotent`,
+and `idempotency_ignore_directive_stable_output` tests exercise that coverage.
 
 Run the focused checks while iterating:
 
@@ -70,6 +81,7 @@ Run the focused checks while iterating:
 cargo test --locked --test test idempotency_static
 cargo test --locked --test test statics
 cargo test --locked --test test comments
+cargo test --locked --test test ignore
 ```
 
 Run the complete locked Rust suite before handoff:

--- a/docs/comment-placement-and-idempotency.md
+++ b/docs/comment-placement-and-idempotency.md
@@ -59,6 +59,11 @@ The static fixtures under `tests/static/` cover the method-chain and unbraced
 `idempotency_static` test formats each fixture twice with the same
 `tests/configs/.afmt_static.toml` configuration.
 
+The ignore directive fixtures under `tests/ignore/` cover verbatim preservation
+of a deliberately non-canonical node, internal blank lines, surrounding normal
+formatting, and stable marker-bearing output. The `ignore` scenario and
+`idempotency_ignore_directive_stable_output` test exercise that coverage.
+
 Run the focused checks while iterating:
 
 ```bash

--- a/docs/comment-placement-and-idempotency.md
+++ b/docs/comment-placement-and-idempotency.md
@@ -32,24 +32,34 @@ styles.
 
 ## Ignored nodes
 
-`// afmt:ignore`, `//afmt:ignore`, and `/* afmt:ignore */` are recognized when
-they are the last standalone pre-comment for a node. The node's original
-source bytes are emitted unchanged, including internal blank lines, while the
-marker itself is omitted from the output. A marker between annotations and a
-declaration applies to the complete declaration, rather than to its first
-modifier.
+A comment is a directive when its delimiters are stripped and its first
+whitespace-separated token is `afmt:ignore`. That accepts `// afmt:ignore`,
+`//afmt:ignore`, `/* afmt:ignore */`, and a trailing free-text reason such as
+`// afmt:ignore column alignment is meaningful`. A near miss like
+`// afmt:ignored` is not a directive and formats normally, so a marker that
+does not take effect is either honored elsewhere or reported.
+
+A directive applies when it is the last standalone pre-comment for a node. The
+node's original source bytes are emitted unchanged, including internal blank
+lines. A marker between annotations and a declaration applies to the complete
+declaration, rather than to its first modifier.
+
+The marker is printed alongside the source it preserves, so ignoring a node is
+idempotent: the marker is still there for the next run to find, and a file
+produced by `afmt --write` passes `afmt --check`. `collect_comments` promotes
+an annotation-adjacent marker into the enclosing declaration's bucket, which
+places it inside the preserved span; `build_with_comments_core` detects that
+case with `Comment::is_within` and lets the verbatim bytes carry the marker
+instead of printing it twice.
 
 Multiline preserved source forces its surrounding groups to break so width
 accounting remains correct. Its interior indentation is raw source and is not
 re-anchored to the formatter's current indentation level.
 
 If a recognized marker has no eligible following node, afmt retains the marker
-and emits a warning on stderr. This is an intentional escape hatch from normal
-formatting, so a deliberately non-canonical ignored node can be reformatted on
-a later invocation: once an honored marker has been consumed, a new formatting
-run has no way to identify that node. The idempotency guarantee applies when
-the preserved bytes are already stable, as covered by
-`idempotency_ignore_directive_stable_output`.
+and emits a warning on stderr. An applied marker never warns; `Comment` tracks
+that with `ignore_honored`, which `build_with_comments_core` sets before the
+marker is printed.
 
 ## Implementation boundaries
 
@@ -72,8 +82,14 @@ The static fixtures under `tests/static/` cover the method-chain and unbraced
 The ignore directive fixtures under `tests/ignore/` cover verbatim preservation
 of deliberately non-canonical nodes, internal blank lines, multiline layout,
 inner punctuation, annotation and loop targeting, and recognized marker
-spellings. The `ignore` scenario, `ignored_inner_punctuation_is_idempotent`,
-and `idempotency_ignore_directive_stable_output` tests exercise that coverage.
+spellings including a trailing reason. Because the marker is preserved, every
+fixture is expected to round-trip:
+`ignore_directive_regressions_match_expected_output` asserts each one matches
+its `.cls` and is unchanged by a second pass. The `ignore` scenario (also part
+of `all`), `ignored_inner_punctuation_is_idempotent`, and
+`idempotency_ignore_directive_stable_output` exercise the rest of that
+coverage, and `honored_ignore_directive_does_not_warn` pairs with
+`unhonored_ignore_directive_warns_and_is_preserved` over the stderr contract.
 
 Run the focused checks while iterating:
 

--- a/docs/comment-placement-and-idempotency.md
+++ b/docs/comment-placement-and-idempotency.md
@@ -42,7 +42,12 @@ does not take effect is either honored elsewhere or reported.
 A directive applies when it is the last standalone pre-comment for a node. The
 node's original source bytes are emitted unchanged, including internal blank
 lines. A marker between annotations and a declaration applies to the complete
-declaration, rather than to its first modifier.
+declaration, rather than to the node the parser happens to hand back next.
+That node depends on what the declaration says: with an access modifier the
+marker lands inside `modifiers`, in front of the first `modifier`; with
+annotations alone `modifiers` closes after the annotation and the marker
+becomes a sibling of the type. `ignore_promotion_target` recognizes both and
+promotes to the declaration either way.
 
 The marker is printed alongside the source it preserves, so ignoring a node is
 idempotent: the marker is still there for the next run to find, and a file
@@ -57,9 +62,20 @@ accounting remains correct. Its interior indentation is raw source and is not
 re-anchored to the formatter's current indentation level.
 
 If a recognized marker has no eligible following node, afmt retains the marker
-and emits a warning on stderr. An applied marker never warns; `Comment` tracks
-that with `ignore_honored`, which `build_with_comments_core` sets before the
-marker is printed.
+and emits a warning on stderr:
+
+```
+Warning: force-app/main/default/classes/Example.cls:12:5: afmt:ignore could not be applied; directive was preserved
+```
+
+The location is the marker's own one-based line and column. The prefix is the
+path afmt was given, `<stdin>` when the source arrived on stdin, and absent
+for a library caller that formatted a string through
+`Formatter::try_format_source`; `Formatter::try_format_source_with_origin`
+supplies one.
+
+An applied marker never warns; `Comment` tracks that with `ignore_honored`,
+which `build_with_comments_core` sets before the marker is printed.
 
 ## Implementation boundaries
 
@@ -81,15 +97,22 @@ The static fixtures under `tests/static/` cover the method-chain and unbraced
 
 The ignore directive fixtures under `tests/ignore/` cover verbatim preservation
 of deliberately non-canonical nodes, internal blank lines, multiline layout,
-inner punctuation, annotation and loop targeting, and recognized marker
-spellings including a trailing reason. Because the marker is preserved, every
-fixture is expected to round-trip:
-`ignore_directive_regressions_match_expected_output` asserts each one matches
-its `.cls` and is unchanged by a second pass. The `ignore` scenario (also part
-of `all`), `ignored_inner_punctuation_is_idempotent`, and
+inner punctuation, annotation and loop targeting, declarations carrying an
+annotation with no access modifier, and recognized marker spellings including a
+trailing reason. Because the marker is preserved, every fixture is expected to
+round-trip: `ignore_directive_regressions_match_expected_output` asserts each
+one matches its `.cls` and is unchanged by a second pass. The `ignore` scenario
+(also part of `all`), `ignored_inner_punctuation_is_idempotent`, and
 `idempotency_ignore_directive_stable_output` exercise the rest of that
-coverage, and `honored_ignore_directive_does_not_warn` pairs with
-`unhonored_ignore_directive_warns_and_is_preserved` over the stderr contract.
+coverage.
+
+Three tests hold the stderr contract:
+`honored_ignore_directive_does_not_warn` asserts an applied marker stays
+silent, `unhonored_ignore_directive_warns_and_is_preserved` asserts the marker
+survives the run that warns about it, and
+`unhonored_ignore_directive_warning_locates_each_file` plus
+`unhonored_ignore_directive_warning_labels_stdin` pin the `path:line:column`
+prefix over a directory of several files and over stdin.
 
 Run the focused checks while iterating:
 

--- a/docs/comment-placement-and-idempotency.md
+++ b/docs/comment-placement-and-idempotency.md
@@ -30,6 +30,17 @@ following Apex node.
 These placements are attachment behavior, not alternate brace or indentation
 styles.
 
+## Ignored nodes
+
+`// afmt:ignore` is consumed when it is the last pre-comment for a node. The
+node's original source bytes are emitted unchanged, including internal blank
+lines, while the marker itself is omitted from the output. This is an
+intentional escape hatch from normal formatting, so a deliberately
+non-canonical ignored node can be reformatted on a later invocation: once the
+marker has been consumed, a new formatting run has no way to identify that
+node. The idempotency guarantee applies when the preserved bytes are already
+stable, as covered by `idempotency_ignore_directive_stable_output`.
+
 ## Implementation boundaries
 
 - `src/utility.rs::collect_comments` attaches same-row comments after an

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,6 +17,8 @@ pub type CommentMap = HashMap<usize, CommentBucket>;
 pub struct NodeContext {
     pub id: usize,
     pub punc: Option<Punctuation>,
+    pub start_byte: usize,
+    pub end_byte: usize,
 }
 
 impl NodeContext {
@@ -25,6 +27,8 @@ impl NodeContext {
         Self {
             id: node.id(),
             punc: Punctuation::from(node),
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
         }
     }
 
@@ -33,6 +37,8 @@ impl NodeContext {
         Self {
             id: node.id(),
             punc: Punctuation::from_inner(node),
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
         }
     }
 
@@ -41,6 +47,8 @@ impl NodeContext {
         Self {
             id: node.id(),
             punc: None,
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
         }
     }
 }
@@ -75,6 +83,8 @@ pub struct Comment {
     pub comment_type: CommentType,
     pub metadata: CommentMetadata,
     pub is_printed: Rc<Cell<bool>>,
+    pub start_byte: usize,
+    pub end_byte: usize,
 }
 
 impl Comment {
@@ -99,6 +109,8 @@ impl Comment {
             comment_type,
             metadata,
             is_printed: Rc::new(Cell::new(false)),
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -86,6 +86,9 @@ pub struct Comment {
     pub ignore_honored: Rc<Cell<bool>>,
     pub start_byte: usize,
     pub end_byte: usize,
+    // One-based, so a diagnostic can be pasted straight into an editor.
+    pub start_line: usize,
+    pub start_column: usize,
 }
 
 impl Comment {
@@ -104,6 +107,8 @@ impl Comment {
             _ => panic_unknown_node(node, "Comment"),
         };
 
+        let start = node.start_position();
+
         Self {
             //id,
             value,
@@ -113,6 +118,8 @@ impl Comment {
             ignore_honored: Rc::new(Cell::new(false)),
             start_byte: node.start_byte(),
             end_byte: node.end_byte(),
+            start_line: start.row + 1,
+            start_column: start.column + 1,
         }
     }
 
@@ -171,8 +178,8 @@ impl<'a> DocBuild<'a> for Comment {
         // only warn when it reaches this path without having been applied.
         if crate::utility::is_ignore_directive(self) && !self.is_ignore_honored() {
             eprintln!(
-                "Warning: afmt:ignore could not be applied at byte {}; directive was preserved",
-                self.start_byte
+                "Warning: {}: afmt:ignore could not be applied; directive was preserved",
+                crate::utility::source_location(self.start_line, self.start_column)
             );
         }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -83,6 +83,7 @@ pub struct Comment {
     pub comment_type: CommentType,
     pub metadata: CommentMetadata,
     pub is_printed: Rc<Cell<bool>>,
+    pub ignore_honored: Rc<Cell<bool>>,
     pub start_byte: usize,
     pub end_byte: usize,
 }
@@ -109,6 +110,7 @@ impl Comment {
             comment_type,
             metadata,
             is_printed: Rc::new(Cell::new(false)),
+            ignore_honored: Rc::new(Cell::new(false)),
             start_byte: node.start_byte(),
             end_byte: node.end_byte(),
         }
@@ -146,6 +148,18 @@ impl Comment {
         self.is_printed.get()
     }
 
+    pub fn is_within(&self, start_byte: usize, end_byte: usize) -> bool {
+        self.start_byte >= start_byte && self.end_byte <= end_byte
+    }
+
+    pub fn mark_ignore_as_honored(&self) {
+        self.ignore_honored.set(true);
+    }
+
+    pub fn is_ignore_honored(&self) -> bool {
+        self.ignore_honored.get()
+    }
+
     pub fn mark_as_inline_post_comment(&mut self) {
         self.metadata.has_leading_content = true;
     }
@@ -153,7 +167,9 @@ impl Comment {
 
 impl<'a> DocBuild<'a> for Comment {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
-        if crate::utility::is_ignore_directive(self) {
+        // An honored directive is printed alongside the source it preserves, so
+        // only warn when it reaches this path without having been applied.
+        if crate::utility::is_ignore_directive(self) && !self.is_ignore_honored() {
             eprintln!(
                 "Warning: afmt:ignore could not be applied at byte {}; directive was preserved",
                 self.start_byte

--- a/src/context.rs
+++ b/src/context.rs
@@ -309,6 +309,8 @@ impl CommentMetadata {
 pub struct Punctuation {
     pub type_: PuncuationType,
     pub id: usize,
+    pub start_byte: usize,
+    pub end_byte: usize,
 }
 
 impl Punctuation {
@@ -317,10 +319,14 @@ impl Punctuation {
             "," => Self {
                 type_: PuncuationType::Comma,
                 id: node.id(),
+                start_byte: node.start_byte(),
+                end_byte: node.end_byte(),
             },
             ";" => Self {
                 type_: PuncuationType::Semicolon,
                 id: node.id(),
+                start_byte: node.start_byte(),
+                end_byte: node.end_byte(),
             },
             _ => panic_unknown_node(node, "Puncuation"),
         }
@@ -353,6 +359,10 @@ impl Punctuation {
             }
         }
         None
+    }
+
+    pub fn is_within(&self, start_byte: usize, end_byte: usize) -> bool {
+        self.start_byte >= start_byte && self.end_byte <= end_byte
     }
 
     pub fn build_comments<'a>(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -153,6 +153,13 @@ impl Comment {
 
 impl<'a> DocBuild<'a> for Comment {
     fn build_inner(&self, b: &'a DocBuilder<'a>, result: &mut Vec<DocRef<'a>>) {
+        if crate::utility::is_ignore_directive(self) {
+            eprintln!(
+                "Warning: afmt:ignore could not be applied at byte {}; directive was preserved",
+                self.start_byte
+            );
+        }
+
         match self.comment_type {
             CommentType::Line => {
                 result.push(b.txt(&self.value));

--- a/src/data_model.rs
+++ b/src/data_model.rs
@@ -3639,6 +3639,8 @@ impl<'a> DocBuild<'a> for SwitchRule {
 }
 
 #[derive(Debug)]
+// Boxing this AST variant may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum SwitchLabel {
     WhenSObject(WhenSObjectType),
     Expressions(Vec<Expression>),

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -11,6 +11,7 @@ pub enum Doc<'a> {
     NewlineWithNoIndent,
     ForceBreak,        // immediately use multi-line mode in choice(x, y) or group()
     Text(String, u32), // The given text should not contain line breaks
+    Verbatim(String),  // Preserves source bytes and may contain line breaks
     Softline,          // a space or a newline
     Maybeline,         // empty or a newline
     Flat(DocRef<'a>),
@@ -207,6 +208,19 @@ impl<'a> PrettyPrinter<'a> {
                         self.col += width;
                     }
                 }
+                Doc::Verbatim(text) => {
+                    if newline_buffer.is_pending() {
+                        self.insert_newline_with_indent(&mut result, newline_buffer.get_indent());
+                        newline_buffer.clear();
+                    }
+
+                    result.push_str(text);
+                    self.col = text
+                        .rsplit_once('\n')
+                        .map_or(self.col + text.len() as u32, |(_, last_line)| {
+                            last_line.len() as u32
+                        });
+                }
                 Doc::Flat(x) => self.chunks.push(chunk.flat(x)),
                 Doc::Indent(i, x) => self.chunks.push(chunk.indented(*i, x)),
                 Doc::Dedent(i, x) => self.chunks.push(chunk.dedented(*i, x)),
@@ -316,6 +330,18 @@ impl<'a> PrettyPrinter<'a> {
                 }
                 Doc::Text(_, text_width) => {
                     if *text_width <= remaining_width {
+                        remaining_width -= text_width;
+                    } else {
+                        return false;
+                    }
+                }
+                Doc::Verbatim(text) => {
+                    if text.contains('\n') {
+                        return false;
+                    }
+
+                    let text_width = text.len() as u32;
+                    if text_width <= remaining_width {
                         remaining_width -= text_width;
                     } else {
                         return false;

--- a/src/doc_builder.rs
+++ b/src/doc_builder.rs
@@ -195,6 +195,10 @@ impl<'a> DocBuilder<'a> {
         self.arena.alloc(Doc::Text(s, width))
     }
 
+    pub fn verbatim(&'a self, text: impl ToString) -> DocRef<'a> {
+        self.arena.alloc(Doc::Verbatim(text.to_string()))
+    }
+
     pub fn _txt(&'a self, text: impl ToString) -> DocRef<'a> {
         let s = text.to_string();
         let space_s = format!(" {}", s);

--- a/src/enum_def.rs
+++ b/src/enum_def.rs
@@ -54,6 +54,8 @@ impl<'a> DocBuild<'a> for RootMember {
 }
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum ClassMember {
     Field(Box<FieldDeclaration>),
     NestedClass(Box<ClassDeclaration>),
@@ -114,6 +116,8 @@ impl<'a> DocBuild<'a> for ClassMember {
 }
 
 #[derive(Debug)]
+// Boxing these AST variants may affect formatter performance and is tracked separately in md/TODO.md.
+#[allow(clippy::large_enum_variant)]
 pub enum UnannotatedType {
     Simple(SimpleType),
     Array(Box<ArrayType>),

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -138,11 +138,15 @@ impl Formatter {
             ),
         })?;
 
-        let formatted =
-            Self::try_format_source(&source_code, config).map_err(|message| FormatFileError {
-                path: path.to_path_buf(),
-                message,
-            })?;
+        let formatted = Self::try_format_source_with_origin(
+            &source_code,
+            config,
+            Some(&path.display().to_string()),
+        )
+        .map_err(|message| FormatFileError {
+            path: path.to_path_buf(),
+            message,
+        })?;
 
         Ok(FormattedFile {
             changed: source_code != formatted,
@@ -156,6 +160,16 @@ impl Formatter {
 
     pub fn try_format_source(source_code: &str, config: Config) -> Result<String, String> {
         source_formatter::try_format_source(source_code, config)
+    }
+
+    /// Same as [`Formatter::try_format_source`], with a name for the source —
+    /// a path, `<stdin>` — so diagnostics can point back at it.
+    pub fn try_format_source_with_origin(
+        source_code: &str,
+        config: Config,
+        origin: Option<&str>,
+    ) -> Result<String, String> {
+        source_formatter::try_format_source_with_origin(source_code, config, origin)
     }
 
     pub fn parse(source_code: &str) -> Tree {

--- a/src/formatting_session.rs
+++ b/src/formatting_session.rs
@@ -1,19 +1,24 @@
 use crate::context::CommentMap;
 use crate::utility::{
-    clear_thread_comment_map, clear_thread_source_code, collect_comments, set_thread_comment_map,
-    set_thread_source_code,
+    clear_thread_comment_map, clear_thread_source_code, clear_thread_source_origin,
+    collect_comments, set_thread_comment_map, set_thread_source_code, set_thread_source_origin,
 };
 use tree_sitter::Tree;
 
 pub(crate) struct FormattingSession;
 
 impl FormattingSession {
-    pub(crate) fn new(source_code: &str, ast_tree: &Tree) -> Self {
+    /// `origin` names where the source came from — a path, `<stdin>` — and is
+    /// used only to locate diagnostics. `None` when the caller has no name for
+    /// it.
+    pub(crate) fn new(source_code: &str, ast_tree: &Tree, origin: Option<&str>) -> Self {
         clear_thread_source_code();
         clear_thread_comment_map();
+        clear_thread_source_origin();
         let session = Self;
 
         set_thread_source_code(source_code.to_string());
+        set_thread_source_origin(origin.map(str::to_string));
 
         let mut cursor = ast_tree.walk();
         let mut comment_map = CommentMap::new();
@@ -29,5 +34,6 @@ impl Drop for FormattingSession {
     fn drop(&mut self) {
         clear_thread_source_code();
         clear_thread_comment_map();
+        clear_thread_source_origin();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,10 @@ fn run(args: &Args, started: Instant) -> Result<RunSummary, String> {
     run_with_writer(args, started, |path, content| fs::write(path, content))
 }
 
+/// Stands in for a path when the source arrived on stdin, so diagnostics keep
+/// the same `path:line:column` shape they have for files.
+const STDIN_ORIGIN: &str = "<stdin>";
+
 fn format_stdin_source(source: &str, config: Config) -> Result<String, String> {
     // Stdin formatting is a synchronous CLI boundary. Keep the library's public
     // formatter free of process-global hook changes while ensuring a caught
@@ -68,7 +72,7 @@ fn format_stdin_source(source: &str, config: Config) -> Result<String, String> {
     let previous_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_| {}));
     let result = catch_unwind(AssertUnwindSafe(|| {
-        Formatter::try_format_source(source, config)
+        Formatter::try_format_source_with_origin(source, config, Some(STDIN_ORIGIN))
     }));
     std::panic::set_hook(previous_hook);
 

--- a/src/source_formatter.rs
+++ b/src/source_formatter.rs
@@ -91,8 +91,16 @@ pub(crate) fn format_one(source_code: &str, config: Config) -> String {
 }
 
 pub(crate) fn try_format_source(source_code: &str, config: Config) -> Result<String, String> {
+    try_format_source_with_origin(source_code, config, None)
+}
+
+pub(crate) fn try_format_source_with_origin(
+    source_code: &str,
+    config: Config,
+    origin: Option<&str>,
+) -> Result<String, String> {
     match catch_unwind(AssertUnwindSafe(|| {
-        try_format_source_unchecked(source_code, config)
+        try_format_source_unchecked(source_code, config, origin)
     })) {
         Ok(result) => result,
         Err(panic_payload) => Err(format!(
@@ -102,13 +110,17 @@ pub(crate) fn try_format_source(source_code: &str, config: Config) -> Result<Str
     }
 }
 
-fn try_format_source_unchecked(source_code: &str, config: Config) -> Result<String, String> {
+fn try_format_source_unchecked(
+    source_code: &str,
+    config: Config,
+    origin: Option<&str>,
+) -> Result<String, String> {
     config
         .validate()
         .map_err(|error| format!("Invalid formatter configuration: {error}"))?;
 
     let ast_tree = try_parse(source_code)?;
-    let _session = FormattingSession::new(source_code, &ast_tree);
+    let _session = FormattingSession::new(source_code, &ast_tree, origin);
 
     // traverse the tree to build enriched data
     let root: Root = enrich(&ast_tree);

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -395,7 +395,7 @@ where
         let verbatim = with_source_code(|source| {
             source[node_context.start_byte..node_context.end_byte].to_string()
         });
-        result.push(b.txt(verbatim));
+        result.push(b.verbatim(verbatim));
         ignore_comment.mark_as_printed();
         mark_comments_in_range_as_printed(node_context.start_byte, node_context.end_byte);
         return true;

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -377,7 +377,8 @@ pub fn build_with_comments_core<'a, F>(
     node_context: &NodeContext,
     result: &mut Vec<DocRef<'a>>,
     handle_members: F,
-) where
+) -> bool
+where
     F: FnOnce(&'a DocBuilder<'a>, &mut Vec<DocRef<'a>>),
 {
     let bucket = get_comment_bucket(&node_context.id);
@@ -397,7 +398,7 @@ pub fn build_with_comments_core<'a, F>(
         result.push(b.txt(verbatim));
         ignore_comment.mark_as_printed();
         mark_comments_in_range_as_printed(node_context.start_byte, node_context.end_byte);
-        return;
+        return true;
     }
 
     handle_pre_comments(b, &bucket, result);
@@ -407,6 +408,8 @@ pub fn build_with_comments_core<'a, F>(
     } else {
         result.push(b.concat(handle_dangling_comments(b, &bucket)));
     }
+
+    false
 }
 
 pub fn build_with_comments_and_punc<'a, F>(
@@ -417,7 +420,7 @@ pub fn build_with_comments_and_punc<'a, F>(
 ) where
     F: FnOnce(&'a DocBuilder<'a>, &mut Vec<DocRef<'a>>),
 {
-    build_with_comments_core(b, node_context, result, handle_members);
+    let ignored = build_with_comments_core(b, node_context, result, handle_members);
 
     let bucket = get_comment_bucket(&node_context.id);
     if bucket.dangling_comments.is_empty() {
@@ -425,7 +428,9 @@ pub fn build_with_comments_and_punc<'a, F>(
     }
 
     if let Some(ref n) = node_context.punc {
-        result.push(n.build(b));
+        if !ignored || !n.is_within(node_context.start_byte, node_context.end_byte) {
+            result.push(n.build(b));
+        }
     }
 }
 
@@ -438,12 +443,14 @@ pub fn build_with_comments_and_punc_attached<'a, F>(
 ) where
     F: FnOnce(&'a DocBuilder<'a>, &mut Vec<DocRef<'a>>),
 {
-    build_with_comments_core(b, node_context, result, handle_members);
+    let ignored = build_with_comments_core(b, node_context, result, handle_members);
 
     let bucket = get_comment_bucket(&node_context.id);
 
     if let Some(ref n) = node_context.punc {
-        result.push(n.build(b));
+        if !ignored || !n.is_within(node_context.start_byte, node_context.end_byte) {
+            result.push(n.build(b));
+        }
     }
 
     if bucket.dangling_comments.is_empty() {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -56,6 +56,29 @@ pub fn with_source_code<T>(callback: impl FnOnce(&str) -> T) -> T {
 }
 
 thread_local! {
+    // Where the source being formatted came from, for diagnostics only. `None`
+    // when a library caller formats a string that has no origin to report.
+    static THREAD_SOURCE_ORIGIN: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+pub fn set_thread_source_origin(origin: Option<String>) {
+    THREAD_SOURCE_ORIGIN.with(|o| *o.borrow_mut() = origin);
+}
+
+pub fn clear_thread_source_origin() {
+    THREAD_SOURCE_ORIGIN.with(|o| o.borrow_mut().take());
+}
+
+/// Renders `line:column`, prefixed with the source origin when one is known,
+/// matching the `Prefix: path: message` shape the CLI uses elsewhere.
+pub fn source_location(line: usize, column: usize) -> String {
+    THREAD_SOURCE_ORIGIN.with(|o| match o.borrow().as_deref() {
+        Some(origin) => format!("{origin}:{line}:{column}"),
+        None => format!("{line}:{column}"),
+    })
+}
+
+thread_local! {
     static THREAD_COMMENT_MAP: RefCell<Option<CommentMap>> = const { RefCell::new(None) };
 }
 
@@ -77,7 +100,8 @@ pub fn clear_thread_comment_map() {
 pub fn thread_state_is_empty() -> bool {
     let source_empty = THREAD_SOURCE_CODE.with(|sc| sc.borrow().is_none());
     let comments_empty = THREAD_COMMENT_MAP.with(|cm| cm.borrow().is_none());
-    source_empty && comments_empty
+    let origin_empty = THREAD_SOURCE_ORIGIN.with(|o| o.borrow().is_none());
+    source_empty && comments_empty && origin_empty
 }
 
 pub fn get_comment_bucket(node_id: &usize) -> CommentBucket {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -99,6 +99,25 @@ pub fn get_comment_map() -> CommentMap {
     })
 }
 
+fn mark_comments_in_range_as_printed(start_byte: usize, end_byte: usize) {
+    THREAD_COMMENT_MAP.with(|cm| {
+        if let Some(comment_map) = cm.borrow().as_ref() {
+            for bucket in comment_map.values() {
+                for comment in bucket
+                    .pre_comments
+                    .iter()
+                    .chain(bucket.post_comments.iter())
+                    .chain(bucket.dangling_comments.iter())
+                {
+                    if comment.start_byte >= start_byte && comment.end_byte <= end_byte {
+                        comment.mark_as_printed();
+                    }
+                }
+            }
+        }
+    });
+}
+
 #[allow(dead_code)]
 pub fn print_comment_map(tree: &Tree) {
     let comment_map = get_comment_map();
@@ -362,6 +381,25 @@ pub fn build_with_comments_core<'a, F>(
     F: FnOnce(&'a DocBuilder<'a>, &mut Vec<DocRef<'a>>),
 {
     let bucket = get_comment_bucket(&node_context.id);
+
+    if let Some(ignore_comment) = bucket
+        .pre_comments
+        .last()
+        .filter(|comment| comment.value.trim() == "// afmt:ignore")
+    {
+        let mut comments_before_ignore = bucket.clone();
+        comments_before_ignore.pre_comments.pop();
+        handle_pre_comments(b, &comments_before_ignore, result);
+
+        let verbatim = with_source_code(|source| {
+            source[node_context.start_byte..node_context.end_byte].to_string()
+        });
+        result.push(b.txt(verbatim));
+        ignore_comment.mark_as_printed();
+        mark_comments_in_range_as_printed(node_context.start_byte, node_context.end_byte);
+        return;
+    }
+
     handle_pre_comments(b, &bucket, result);
 
     if bucket.dangling_comments.is_empty() {
@@ -677,6 +715,7 @@ pub fn is_bracket_composite_node(node: &Node) -> bool {
 mod tests {
     use super::is_pure_name_path;
     use super::truncate_snippet;
+    use crate::formatter::{Config, Formatter};
     use tree_sitter::{Node, Parser};
 
     fn find_node<'a>(node: Node<'a>, kind: &str, source: &'a str, text: &str) -> Option<Node<'a>> {
@@ -700,6 +739,16 @@ mod tests {
 
         assert_eq!(truncated, format!("{}…", "a".repeat(79)));
         assert!(std::str::from_utf8(truncated.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn ignore_directive_is_consumed_from_formatted_output() {
+        let source = "class Example {\n  // afmt:ignore\n  void   run( ) { return; }\n}\n";
+
+        let formatted = Formatter::format_one(source, Config::default());
+
+        assert!(!formatted.contains("afmt:ignore"));
+        assert!(formatted.contains("void   run( ) { return; }"));
     }
 
     fn assert_name_path(source: &str, kind: &str, text: &str, expected: bool) {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -210,7 +210,11 @@ pub fn is_ignore_directive(comment: &Comment) -> bool {
         return false;
     };
 
-    directive.trim() == "afmt:ignore"
+    // A free-text reason may follow the marker, as in `// afmt:ignore hand-aligned`.
+    directive
+        .split_whitespace()
+        .next()
+        .is_some_and(|marker| marker == "afmt:ignore")
 }
 
 fn is_associable_unnamed_node(node: &Node) -> bool {
@@ -421,12 +425,22 @@ where
         .last()
         .filter(|comment| is_ignore_directive(comment))
     {
-        let mut comments_before_ignore = bucket.clone();
-        comments_before_ignore.pre_comments.pop();
-        handle_pre_comments(b, &comments_before_ignore, result);
+        ignore_comment.mark_ignore_as_honored();
+
+        // A directive promoted past an annotation already sits inside the span
+        // that is preserved verbatim, so printing it again would duplicate it.
+        // Anywhere else it precedes the node and has to be printed explicitly,
+        // which is what keeps the marker available to the next formatting run.
+        if ignore_comment.is_within(node_context.start_byte, node_context.end_byte) {
+            let mut comments_before_ignore = bucket.clone();
+            comments_before_ignore.pre_comments.pop();
+            handle_pre_comments(b, &comments_before_ignore, result);
+        } else {
+            handle_pre_comments(b, &bucket, result);
+        }
 
         let verbatim = with_source_code(|source| {
-            verbatim_source_without_marker(source, node_context, ignore_comment)
+            source[node_context.start_byte..node_context.end_byte].to_string()
         });
         result.push(b.verbatim(verbatim));
         ignore_comment.mark_as_printed();
@@ -443,40 +457,6 @@ where
     }
 
     false
-}
-
-fn verbatim_source_without_marker(
-    source: &str,
-    node_context: &NodeContext,
-    ignore_comment: &Comment,
-) -> String {
-    let source_span = &source[node_context.start_byte..node_context.end_byte];
-    if ignore_comment.start_byte < node_context.start_byte
-        || ignore_comment.end_byte > node_context.end_byte
-    {
-        return source_span.to_string();
-    }
-
-    let marker_start = ignore_comment.start_byte - node_context.start_byte;
-    let marker_end = ignore_comment.end_byte - node_context.start_byte;
-    let line_start = source_span[..marker_start]
-        .rfind('\n')
-        .map_or(0, |index| index + 1);
-    let line_end = source_span[marker_end..]
-        .find('\n')
-        .map_or(source_span.len(), |index| marker_end + index + 1);
-
-    if source_span[line_start..marker_start].trim().is_empty()
-        && source_span[marker_end..line_end].trim().is_empty()
-    {
-        format!("{}{}", &source_span[..line_start], &source_span[line_end..])
-    } else {
-        format!(
-            "{}{}",
-            &source_span[..marker_start],
-            &source_span[marker_end..]
-        )
-    }
 }
 
 pub fn build_with_comments_and_punc<'a, F>(
@@ -816,13 +796,35 @@ mod tests {
     }
 
     #[test]
-    fn ignore_directive_is_consumed_from_formatted_output() {
+    fn ignore_directive_survives_formatting_with_its_node() {
         let source = "class Example {\n  // afmt:ignore\n  void   run( ) { return; }\n}\n";
 
-        let formatted = Formatter::format_one(source, Config::default());
+        let first = Formatter::format_one(source, Config::default());
+        let second = Formatter::format_one(&first, Config::default());
 
-        assert!(!formatted.contains("afmt:ignore"));
-        assert!(formatted.contains("void   run( ) { return; }"));
+        assert!(first.contains("// afmt:ignore"));
+        assert!(first.contains("void   run( ) { return; }"));
+        assert_eq!(
+            first, second,
+            "a preserved marker must keep preserving on later runs"
+        );
+    }
+
+    #[test]
+    fn ignore_directive_accepts_a_trailing_reason() {
+        let marker = |value: &str| {
+            let source = format!("class Example {{\n  {value}\n  Integer   x=1;\n}}\n");
+            Formatter::format_one(&source, Config::default()).contains("Integer   x=1;")
+        };
+
+        assert!(marker("// afmt:ignore"));
+        assert!(marker("//afmt:ignore"));
+        assert!(marker("/* afmt:ignore */"));
+        assert!(marker("// afmt:ignore column alignment is meaningful"));
+        assert!(marker("/* afmt:ignore see JIRA-123 */"));
+        assert!(!marker("// afmt:ignored"));
+        assert!(!marker("// afmt:ignore-next"));
+        assert!(!marker("// not a marker"));
     }
 
     fn assert_name_path(source: &str, kind: &str, text: &str, expected: bool) {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -197,6 +197,22 @@ pub fn is_punctuation_node(node: &Node) -> bool {
     matches!(node.kind(), "," | ";")
 }
 
+pub fn is_ignore_directive(comment: &Comment) -> bool {
+    let value = comment.value.trim();
+    let directive = if let Some(value) = value.strip_prefix("//") {
+        value
+    } else if let Some(value) = value
+        .strip_prefix("/*")
+        .and_then(|value| value.strip_suffix("*/"))
+    {
+        value
+    } else {
+        return false;
+    };
+
+    directive.trim() == "afmt:ignore"
+}
+
 fn is_associable_unnamed_node(node: &Node) -> bool {
     is_punctuation_node(node) || matches!(node.kind(), "else")
 }
@@ -309,6 +325,27 @@ pub fn collect_comments(cursor: &mut TreeCursor, comment_map: &mut CommentMap) {
             // It's an associable node
             let child_id = child.id();
 
+            // A directive between annotations and a declaration can be attached
+            // to the declaration's first modifier. Promote it to the enclosing
+            // declaration so the complete declaration is preserved verbatim.
+            if node.kind() == "modifiers"
+                && child.kind() == "modifier"
+                && pending_pre_comments.last().is_some_and(is_ignore_directive)
+            {
+                let ignore_comment = pending_pre_comments
+                    .pop()
+                    .expect("ignore directive was present");
+                if let Some(parent) = node.parent() {
+                    comment_map
+                        .entry(parent.id())
+                        .or_insert_with(CommentBucket::new)
+                        .pre_comments
+                        .push(ignore_comment);
+                } else {
+                    pending_pre_comments.push(ignore_comment);
+                }
+            }
+
             // Assign any pending comments to the child's pre-comments
             if !pending_pre_comments.is_empty() {
                 comment_map
@@ -359,17 +396,13 @@ pub fn build_with_comments<'a, F>(
 ) where
     F: FnOnce(&'a DocBuilder<'a>, &mut Vec<DocRef<'a>>),
 {
-    let bucket = get_comment_bucket(&node_context.id);
-    handle_pre_comments(b, &bucket, result);
-
-    if bucket.dangling_comments.is_empty() {
-        handle_members(b, result);
-    } else {
-        result.push(b.concat(handle_dangling_comments(b, &bucket)));
-        return;
+    let ignored = build_with_comments_core(b, node_context, result, handle_members);
+    if !ignored {
+        let bucket = get_comment_bucket(&node_context.id);
+        if bucket.dangling_comments.is_empty() {
+            handle_post_comments(b, &bucket, result);
+        }
     }
-
-    handle_post_comments(b, &bucket, result);
 }
 
 pub fn build_with_comments_core<'a, F>(
@@ -386,14 +419,14 @@ where
     if let Some(ignore_comment) = bucket
         .pre_comments
         .last()
-        .filter(|comment| comment.value.trim() == "// afmt:ignore")
+        .filter(|comment| is_ignore_directive(comment))
     {
         let mut comments_before_ignore = bucket.clone();
         comments_before_ignore.pre_comments.pop();
         handle_pre_comments(b, &comments_before_ignore, result);
 
         let verbatim = with_source_code(|source| {
-            source[node_context.start_byte..node_context.end_byte].to_string()
+            verbatim_source_without_marker(source, node_context, ignore_comment)
         });
         result.push(b.verbatim(verbatim));
         ignore_comment.mark_as_printed();
@@ -410,6 +443,40 @@ where
     }
 
     false
+}
+
+fn verbatim_source_without_marker(
+    source: &str,
+    node_context: &NodeContext,
+    ignore_comment: &Comment,
+) -> String {
+    let source_span = &source[node_context.start_byte..node_context.end_byte];
+    if ignore_comment.start_byte < node_context.start_byte
+        || ignore_comment.end_byte > node_context.end_byte
+    {
+        return source_span.to_string();
+    }
+
+    let marker_start = ignore_comment.start_byte - node_context.start_byte;
+    let marker_end = ignore_comment.end_byte - node_context.start_byte;
+    let line_start = source_span[..marker_start]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    let line_end = source_span[marker_end..]
+        .find('\n')
+        .map_or(source_span.len(), |index| marker_end + index + 1);
+
+    if source_span[line_start..marker_start].trim().is_empty()
+        && source_span[marker_end..line_end].trim().is_empty()
+    {
+        format!("{}{}", &source_span[..line_start], &source_span[line_end..])
+    } else {
+        format!(
+            "{}{}",
+            &source_span[..marker_start],
+            &source_span[marker_end..]
+        )
+    }
 }
 
 pub fn build_with_comments_and_punc<'a, F>(

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -221,6 +221,39 @@ fn is_associable_unnamed_node(node: &Node) -> bool {
     is_punctuation_node(node) || matches!(node.kind(), "else")
 }
 
+// The node an ignore directive pending in front of `child` should preserve,
+// when annotations have already pulled the directive inside the declaration.
+// Returns `None` when the directive belongs to `child` as it stands.
+fn ignore_promotion_target(node: &Node, child: &Node) -> Option<usize> {
+    // With an access modifier present the directive lands inside `modifiers`,
+    // in front of the first `modifier`.
+    if node.kind() == "modifiers" && child.kind() == "modifier" {
+        return node.parent().map(|declaration| declaration.id());
+    }
+
+    // With annotations alone there is no `modifier` to hold it, so the parser
+    // closes `modifiers` and the directive becomes a sibling of the type.
+    if follows_modifiers(child) {
+        return Some(node.id());
+    }
+
+    None
+}
+
+// Whether the nearest preceding non-comment sibling of `node` is a `modifiers`
+// node, meaning `node` is the first thing a declaration says after its
+// annotations and modifiers.
+fn follows_modifiers(node: &Node) -> bool {
+    let mut previous = node.prev_sibling();
+    while let Some(sibling) = previous {
+        if !sibling.is_extra() {
+            return sibling.kind() == "modifiers";
+        }
+        previous = sibling.prev_sibling();
+    }
+    false
+}
+
 pub fn collect_comments(cursor: &mut TreeCursor, comment_map: &mut CommentMap) {
     let node = cursor.node();
 
@@ -329,24 +362,20 @@ pub fn collect_comments(cursor: &mut TreeCursor, comment_map: &mut CommentMap) {
             // It's an associable node
             let child_id = child.id();
 
-            // A directive between annotations and a declaration can be attached
-            // to the declaration's first modifier. Promote it to the enclosing
-            // declaration so the complete declaration is preserved verbatim.
-            if node.kind() == "modifiers"
-                && child.kind() == "modifier"
-                && pending_pre_comments.last().is_some_and(is_ignore_directive)
-            {
-                let ignore_comment = pending_pre_comments
-                    .pop()
-                    .expect("ignore directive was present");
-                if let Some(parent) = node.parent() {
+            // A directive between annotations and a declaration attaches to
+            // whichever node the parser hands back next. Promote it to the
+            // enclosing declaration so the complete declaration is preserved
+            // verbatim rather than just that node.
+            if pending_pre_comments.last().is_some_and(is_ignore_directive) {
+                if let Some(declaration_id) = ignore_promotion_target(&node, &child) {
+                    let ignore_comment = pending_pre_comments
+                        .pop()
+                        .expect("ignore directive was present");
                     comment_map
-                        .entry(parent.id())
+                        .entry(declaration_id)
                         .or_insert_with(CommentBucket::new)
                         .pre_comments
                         .push(ignore_comment);
-                } else {
-                    pending_pre_comments.push(ignore_comment);
                 }
             }
 

--- a/tests/ignore/IgnoreDirective.cls
+++ b/tests/ignore/IgnoreDirective.cls
@@ -1,0 +1,19 @@
+public class IgnoreDirective {
+  // keep this comment
+  void   handFormatted( ) {
+
+    // preserve this internal comment
+
+    List<String> values = new List<String>();
+
+    values.add('one')  .add('two');
+  }
+
+  void   builder( ) { return; }
+
+  void formatted() {
+    Integer   value=  2;
+
+    Integer value = 1;
+  }
+}

--- a/tests/ignore/IgnoreDirective.cls
+++ b/tests/ignore/IgnoreDirective.cls
@@ -1,5 +1,6 @@
 public class IgnoreDirective {
   // keep this comment
+  // afmt:ignore
   void   handFormatted( ) {
 
     // preserve this internal comment
@@ -9,9 +10,11 @@ public class IgnoreDirective {
     values.add('one')  .add('two');
   }
 
+  // afmt:ignore
   void   builder( ) { return; }
 
   void formatted() {
+    // afmt:ignore
     Integer   value=  2;
 
     Integer value = 1;

--- a/tests/ignore/IgnoreDirective.in
+++ b/tests/ignore/IgnoreDirective.in
@@ -1,0 +1,22 @@
+public class IgnoreDirective {
+  // keep this comment
+  // afmt:ignore
+  void   handFormatted( ) {
+
+    // preserve this internal comment
+
+    List<String> values = new List<String>();
+
+    values.add('one')  .add('two');
+  }
+
+  // afmt:ignore
+  void   builder( ) { return; }
+
+  void   formatted( ) {
+    // afmt:ignore
+    Integer   value=  2;
+
+    Integer value=1;
+  }
+}

--- a/tests/ignore/IgnoreDirectiveAnnotationWithoutModifier.cls
+++ b/tests/ignore/IgnoreDirectiveAnnotationWithoutModifier.cls
@@ -1,0 +1,25 @@
+public class IgnoreDirectiveAnnotationWithoutModifier {
+  @AuraEnabled
+  // afmt:ignore
+  List < String >   noModifier( ) {
+    Integer   x=1;
+    return null;
+  }
+
+  @TestVisible
+  // afmt:ignore
+  Map < String , String >   lookup   =   new Map<String, String>{ 'a'  =>  'b' };
+
+  @AuraEnabled
+  // afmt:ignore
+  public   List < String >   withModifier( ) {
+    Integer   x=1;
+    return null;
+  }
+
+  // afmt:ignore
+  List < String >   withoutAnnotation( ) {
+    Integer   x=1;
+    return null;
+  }
+}

--- a/tests/ignore/IgnoreDirectiveAnnotationWithoutModifier.in
+++ b/tests/ignore/IgnoreDirectiveAnnotationWithoutModifier.in
@@ -1,0 +1,25 @@
+public class IgnoreDirectiveAnnotationWithoutModifier {
+  @AuraEnabled
+  // afmt:ignore
+  List < String >   noModifier( ) {
+    Integer   x=1;
+    return null;
+  }
+
+  @TestVisible
+  // afmt:ignore
+  Map < String , String >   lookup   =   new Map<String, String>{ 'a'  =>  'b' };
+
+  @AuraEnabled
+  // afmt:ignore
+  public   List < String >   withModifier( ) {
+    Integer   x=1;
+    return null;
+  }
+
+  // afmt:ignore
+  List < String >   withoutAnnotation( ) {
+    Integer   x=1;
+    return null;
+  }
+}

--- a/tests/ignore/IgnoreDirectiveMultiline.cls
+++ b/tests/ignore/IgnoreDirectiveMultiline.cls
@@ -1,0 +1,13 @@
+public class IgnoreDirectiveMultiline {
+  void run() {
+    foo(
+      bar,
+      new Baz(
+        a
+  + b,
+        qqqq
+      ),
+      zzzz
+    );
+  }
+}

--- a/tests/ignore/IgnoreDirectiveMultiline.cls
+++ b/tests/ignore/IgnoreDirectiveMultiline.cls
@@ -3,6 +3,7 @@ public class IgnoreDirectiveMultiline {
     foo(
       bar,
       new Baz(
+        // afmt:ignore
         a
   + b,
         qqqq

--- a/tests/ignore/IgnoreDirectiveMultiline.in
+++ b/tests/ignore/IgnoreDirectiveMultiline.in
@@ -1,0 +1,8 @@
+public class IgnoreDirectiveMultiline {
+  void run() {
+    foo(bar, new Baz(
+      // afmt:ignore
+      a
+  + b, qqqq), zzzz);
+  }
+}

--- a/tests/ignore/IgnoreDirectivePunctuation.cls
+++ b/tests/ignore/IgnoreDirectivePunctuation.cls
@@ -1,15 +1,22 @@
 public class IgnoreDirectivePunctuation {
   void statements() {
     while (true) {
+      // afmt:ignore
       break;
     }
 
     for (Integer i = 0; i < 3; i++) {
+      // afmt:ignore
       continue;
     }
 
+    // afmt:ignore
     return;
   }
 
-  public String property { get; set; }
+  public String property {
+    // afmt:ignore
+    get;
+    set;
+  }
 }

--- a/tests/ignore/IgnoreDirectivePunctuation.cls
+++ b/tests/ignore/IgnoreDirectivePunctuation.cls
@@ -1,0 +1,15 @@
+public class IgnoreDirectivePunctuation {
+  void statements() {
+    while (true) {
+      break;
+    }
+
+    for (Integer i = 0; i < 3; i++) {
+      continue;
+    }
+
+    return;
+  }
+
+  public String property { get; set; }
+}

--- a/tests/ignore/IgnoreDirectivePunctuation.in
+++ b/tests/ignore/IgnoreDirectivePunctuation.in
@@ -1,0 +1,22 @@
+public class IgnoreDirectivePunctuation {
+  void statements() {
+    while (true) {
+      // afmt:ignore
+      break;
+    }
+
+    for (Integer i = 0; i < 3; i++) {
+      // afmt:ignore
+      continue;
+    }
+
+    // afmt:ignore
+    return;
+  }
+
+  public String property {
+    // afmt:ignore
+    get;
+    set;
+  }
+}

--- a/tests/ignore/IgnoreDirectiveReason.cls
+++ b/tests/ignore/IgnoreDirectiveReason.cls
@@ -1,0 +1,10 @@
+public class IgnoreDirectiveReason {
+  // afmt:ignore column alignment is meaningful here
+  Integer   matrix=1;
+
+  /* afmt:ignore see JIRA-123 */
+  Integer   legacy=2;
+
+  // afmt:ignored is not a marker
+  Integer normal = 3;
+}

--- a/tests/ignore/IgnoreDirectiveReason.in
+++ b/tests/ignore/IgnoreDirectiveReason.in
@@ -1,0 +1,10 @@
+public class IgnoreDirectiveReason {
+  // afmt:ignore column alignment is meaningful here
+  Integer   matrix=1;
+
+  /* afmt:ignore see JIRA-123 */
+  Integer   legacy=2;
+
+  // afmt:ignored is not a marker
+  Integer   normal=3;
+}

--- a/tests/ignore/IgnoreDirectiveStable.cls
+++ b/tests/ignore/IgnoreDirectiveStable.cls
@@ -1,0 +1,5 @@
+public class IgnoreDirectiveStable {
+  void stable() {
+    Integer value = 1;
+  }
+}

--- a/tests/ignore/IgnoreDirectiveStable.cls
+++ b/tests/ignore/IgnoreDirectiveStable.cls
@@ -1,4 +1,5 @@
 public class IgnoreDirectiveStable {
+  // afmt:ignore
   void stable() {
     Integer value = 1;
   }

--- a/tests/ignore/IgnoreDirectiveStable.in
+++ b/tests/ignore/IgnoreDirectiveStable.in
@@ -1,0 +1,6 @@
+public class IgnoreDirectiveStable {
+  // afmt:ignore
+  void stable() {
+    Integer value = 1;
+  }
+}

--- a/tests/ignore/IgnoreDirectiveTargets.cls
+++ b/tests/ignore/IgnoreDirectiveTargets.cls
@@ -1,12 +1,16 @@
 public class IgnoreDirectiveTargets {
   @AuraEnabled
+  // afmt:ignore
   public   void annotated( ) { }
 
   void run() {
+    // afmt:ignore
     while (x) { f(); }
 
+    //afmt:ignore
     Integer   x=1;
 
+    /* afmt:ignore */
     Integer   y=2;
   }
 }

--- a/tests/ignore/IgnoreDirectiveTargets.cls
+++ b/tests/ignore/IgnoreDirectiveTargets.cls
@@ -1,0 +1,12 @@
+public class IgnoreDirectiveTargets {
+  @AuraEnabled
+  public   void annotated( ) { }
+
+  void run() {
+    while (x) { f(); }
+
+    Integer   x=1;
+
+    Integer   y=2;
+  }
+}

--- a/tests/ignore/IgnoreDirectiveTargets.in
+++ b/tests/ignore/IgnoreDirectiveTargets.in
@@ -1,0 +1,16 @@
+public class IgnoreDirectiveTargets {
+  @AuraEnabled
+  // afmt:ignore
+  public   void annotated( ) { }
+
+  void run() {
+    // afmt:ignore
+    while (x) { f(); }
+
+    //afmt:ignore
+    Integer   x=1;
+
+    /* afmt:ignore */
+    Integer   y=2;
+  }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -124,6 +124,7 @@ mod tests {
             "IgnoreDirectiveMultiline",
             "IgnoreDirectiveTargets",
             "IgnoreDirectiveReason",
+            "IgnoreDirectiveAnnotationWithoutModifier",
         ] {
             let source = std::fs::read_to_string(format!("tests/ignore/{fixture}.in"))
                 .expect("ignore source fixture should be readable");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -119,19 +119,30 @@ mod tests {
     #[test]
     fn ignore_directive_regressions_match_expected_output() {
         for fixture in [
+            "IgnoreDirective",
             "IgnoreDirectivePunctuation",
             "IgnoreDirectiveMultiline",
             "IgnoreDirectiveTargets",
+            "IgnoreDirectiveReason",
         ] {
             let source = std::fs::read_to_string(format!("tests/ignore/{fixture}.in"))
                 .expect("ignore source fixture should be readable");
             let expected = std::fs::read_to_string(format!("tests/ignore/{fixture}.cls"))
                 .expect("ignore expected output should be readable");
             let first = Formatter::format_one(&source, Config::default());
+            let second = Formatter::format_one(&first, Config::default());
 
             assert_eq!(
                 first, expected,
                 "{fixture} first pass should match its fixture"
+            );
+            assert!(
+                first.contains("afmt:ignore"),
+                "{fixture} should keep its directive available to later runs"
+            );
+            assert_eq!(
+                first, second,
+                "{fixture} should be stable once its directive is preserved"
             );
         }
     }
@@ -169,6 +180,39 @@ mod tests {
         assert!(String::from_utf8_lossy(&output.stdout).contains("// afmt:ignore"));
         assert!(String::from_utf8_lossy(&output.stderr)
             .contains("Warning: afmt:ignore could not be applied"));
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn honored_ignore_directive_does_not_warn() {
+        let directory = std::env::temp_dir().join(format!(
+            "sf-afmt-ignore-directive-honored-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&directory).unwrap();
+        let source_path = directory.join("Honored.cls");
+        fs::write(
+            &source_path,
+            "public class Honored {\n  // afmt:ignore\n  Integer   x=1;\n}\n",
+        )
+        .unwrap();
+
+        let output = Command::new(env!("CARGO_BIN_EXE_afmt"))
+            .arg(&source_path)
+            .output()
+            .expect("failed to execute afmt");
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("// afmt:ignore"));
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("afmt:ignore"),
+            "an applied directive should not warn"
+        );
 
         fs::remove_dir_all(directory).unwrap();
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -180,9 +180,79 @@ mod tests {
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("// afmt:ignore"));
         assert!(String::from_utf8_lossy(&output.stderr)
-            .contains("Warning: afmt:ignore could not be applied"));
+            .contains("afmt:ignore could not be applied; directive was preserved"));
 
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn unhonored_ignore_directive_warning_locates_each_file() {
+        let directory = std::env::temp_dir().join(format!(
+            "sf-afmt-ignore-directive-warning-location-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&directory).unwrap();
+        let first_path = directory.join("A.cls");
+        let second_path = directory.join("B.cls");
+        fs::write(&first_path, "public class A {}\n  // afmt:ignore\n").unwrap();
+        fs::write(&second_path, "public class B {}\n// afmt:ignore\n").unwrap();
+
+        let output = Command::new(env!("CARGO_BIN_EXE_afmt"))
+            .arg("--check")
+            .arg(&directory)
+            .output()
+            .expect("failed to execute afmt");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        for (path, line, column) in [(&first_path, 2, 3), (&second_path, 2, 1)] {
+            let expected = format!(
+                "Warning: {}:{}:{}: afmt:ignore could not be applied; directive was preserved",
+                path.display(),
+                line,
+                column
+            );
+            assert!(
+                stderr.contains(&expected),
+                "expected `{expected}` in stderr:\n{stderr}"
+            );
+        }
+        assert!(
+            !stderr.contains("at byte"),
+            "byte offsets are not somewhere an editor can jump to:\n{stderr}"
+        );
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn unhonored_ignore_directive_warning_labels_stdin() {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_afmt"))
+            .arg("-")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to execute afmt");
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin should be piped")
+            .write_all(b"public class Stdin {}\n// afmt:ignore\n")
+            .expect("source should be written to stdin");
+        let output = child.wait_with_output().expect("afmt should exit");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(output.status.success());
+        assert!(
+            stderr.contains(
+                "Warning: <stdin>:2:1: afmt:ignore could not be applied; directive was preserved"
+            ),
+            "expected a `<stdin>` location in stderr:\n{stderr}"
+        );
     }
 
     #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -130,8 +130,14 @@ mod tests {
             let first = Formatter::format_one(&source, Config::default());
             let second = Formatter::format_one(&first, Config::default());
 
-            assert_eq!(first, expected, "{fixture} first pass should match its fixture");
-            assert_eq!(first, second, "{fixture} should be stable on the second pass");
+            assert_eq!(
+                first, expected,
+                "{fixture} first pass should match its fixture"
+            );
+            assert_eq!(
+                first, second,
+                "{fixture} should be stable on the second pass"
+            );
         }
     }
 
@@ -147,11 +153,7 @@ mod tests {
         ));
         fs::create_dir(&directory).unwrap();
         let source_path = directory.join("Warning.cls");
-        fs::write(
-            &source_path,
-            "public class Warning {}\n// afmt:ignore\n",
-        )
-        .unwrap();
+        fs::write(&source_path, "public class Warning {}\n// afmt:ignore\n").unwrap();
 
         let output = Command::new(env!("CARGO_BIN_EXE_afmt"))
             .arg(&source_path)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -104,12 +104,15 @@ mod tests {
     }
 
     #[test]
-    fn idempotency_ignore_formatted_output() {
-        let source = std::fs::read_to_string("tests/ignore/IgnoreDirective.cls")
+    fn idempotency_ignore_directive_stable_output() {
+        let source = std::fs::read_to_string("tests/ignore/IgnoreDirectiveStable.in")
+            .expect("ignore source fixture should be readable");
+        let expected = std::fs::read_to_string("tests/ignore/IgnoreDirectiveStable.cls")
             .expect("ignore expected output should be readable");
         let first = Formatter::format_one(&source, Config::default());
         let second = Formatter::format_one(&first, Config::default());
 
+        assert_eq!(first, expected);
         assert_eq!(first, second);
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -117,6 +117,56 @@ mod tests {
     }
 
     #[test]
+    fn ignore_directive_regressions_are_idempotent() {
+        for fixture in [
+            "IgnoreDirectivePunctuation",
+            "IgnoreDirectiveMultiline",
+            "IgnoreDirectiveTargets",
+        ] {
+            let source = std::fs::read_to_string(format!("tests/ignore/{fixture}.in"))
+                .expect("ignore source fixture should be readable");
+            let expected = std::fs::read_to_string(format!("tests/ignore/{fixture}.cls"))
+                .expect("ignore expected output should be readable");
+            let first = Formatter::format_one(&source, Config::default());
+            let second = Formatter::format_one(&first, Config::default());
+
+            assert_eq!(first, expected, "{fixture} first pass should match its fixture");
+            assert_eq!(first, second, "{fixture} should be stable on the second pass");
+        }
+    }
+
+    #[test]
+    fn unhonored_ignore_directive_warns_and_is_preserved() {
+        let directory = std::env::temp_dir().join(format!(
+            "sf-afmt-ignore-directive-warning-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&directory).unwrap();
+        let source_path = directory.join("Warning.cls");
+        fs::write(
+            &source_path,
+            "public class Warning {}\n// afmt:ignore\n",
+        )
+        .unwrap();
+
+        let output = Command::new(env!("CARGO_BIN_EXE_afmt"))
+            .arg(&source_path)
+            .output()
+            .expect("failed to execute afmt");
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("// afmt:ignore"));
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("Warning: afmt:ignore could not be applied"));
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn all() {
         let scenarios = [
             ("tests/static", "static"),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -179,6 +179,7 @@ mod tests {
             ("tests/static", "static"),
             ("tests/prettier80", "prettier80"),
             ("tests/comments", "comments"),
+            ("tests/ignore", "ignore"),
         ];
 
         let mut total_tests = 0;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -117,7 +117,7 @@ mod tests {
     }
 
     #[test]
-    fn ignore_directive_regressions_are_idempotent() {
+    fn ignore_directive_regressions_match_expected_output() {
         for fixture in [
             "IgnoreDirectivePunctuation",
             "IgnoreDirectiveMultiline",
@@ -128,17 +128,22 @@ mod tests {
             let expected = std::fs::read_to_string(format!("tests/ignore/{fixture}.cls"))
                 .expect("ignore expected output should be readable");
             let first = Formatter::format_one(&source, Config::default());
-            let second = Formatter::format_one(&first, Config::default());
 
             assert_eq!(
                 first, expected,
                 "{fixture} first pass should match its fixture"
             );
-            assert_eq!(
-                first, second,
-                "{fixture} should be stable on the second pass"
-            );
         }
+    }
+
+    #[test]
+    fn ignored_inner_punctuation_is_idempotent() {
+        let source = std::fs::read_to_string("tests/ignore/IgnoreDirectivePunctuation.in")
+            .expect("punctuation source fixture should be readable");
+        let first = Formatter::format_one(&source, Config::default());
+        let second = Formatter::format_one(&first, Config::default());
+
+        assert_eq!(first, second, "punctuation output should be stable");
     }
 
     #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -66,6 +66,12 @@ mod tests {
     }
 
     #[test]
+    fn ignore() {
+        let (total, failed) = run_scenario("tests/ignore", "ignore");
+        assert_eq!(failed, 0, "{} out of {} tests failed", failed, total);
+    }
+
+    #[test]
     fn idempotency_static() {
         run_idempotency("tests/static", "static", "tests/configs/.afmt_static.toml");
     }
@@ -95,6 +101,16 @@ mod tests {
             "configurable_style",
             "tests/configs/.afmt_configurable_style.toml",
         );
+    }
+
+    #[test]
+    fn idempotency_ignore_formatted_output() {
+        let source = std::fs::read_to_string("tests/ignore/IgnoreDirective.cls")
+            .expect("ignore expected output should be readable");
+        let first = Formatter::format_one(&source, Config::default());
+        let second = Formatter::format_one(&first, Config::default());
+
+        assert_eq!(first, second);
     }
 
     #[test]
@@ -246,6 +262,7 @@ mod tests {
             "prettier80" => run_prettier_test_files(source, "p80"),
             "comments" => run_static_test_files(source),
             "configurable_style" => run_configurable_style_test_files(source),
+            "ignore" => run_static_test_files(source),
             _ => panic!("Unknown scenario: {}", scenario_name),
         });
 


### PR DESCRIPTION
## Summary

Adds `// afmt:ignore` as a per-node escape hatch: marked nodes preserve their original source bytes while surrounding nodes continue through normal formatting. This lets users preserve intentionally hand-formatted Apex without disabling afmt for an entire file or project. Credit to an independent implementation of this in the [maciej-findock/afmt](https://github.com/maciej-findock/afmt) fork, commits 0e14252/7db4c4f, which were used as part of this work.

Closes #138

Related to #9

## Implementation notes

- Captures tree-sitter byte spans for ignored nodes and emits them verbatim, accounting for nested comments.
- Keeps the marker in the output, so a node stays ignored on later runs and `--check` passes on what `--write` produced.
- Recognizes `//afmt:ignore`, `/* afmt:ignore */`, and a trailing reason; a marker above annotations applies to the whole declaration.
- Warns on stderr when a marker can't be honored.
- Adds fixtures, focused tests, README guidance, and idempotency documentation.

## Testing

- Covers preservation, surrounding formatting, nested comments, inner punctuation, annotation and loop targeting, marker spellings, and idempotency. All five ignore fixtures round-trip.
- Validation: `cargo test --locked --all-features` (100 passed), `cargo fmt --all -- --check`, and `cargo clippy --locked --all-targets --all-features -- -D warnings`.

## Review follow-up

@xixiaofinland's three findings are fixed and verified against the original repros.

One divergence needs your call: markers are now **kept** rather than consumed, since consuming them made the hatch last only one run — the `--write`/`--check` failure you flagged. The `IgnoreDirectivePunctuation.cls` you supplied therefore differs: the bug is still fixed (`get;` not `get;;`), but markers remain and the accessor list breaks instead of collapsing to `{ get; set; }`, as any comment there would force. Happy to revert if you prefer consumption.

## Out of scope

- Range-based ignore markers.
- File-level or project-level ignore configuration.
