### PR TITLE
docs: announce VS Code extension and correct config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
 `afmt` (Apex formatting tool) is written in Rust 🦀 and leverages the [tree-sitter sfapex parser](https://github.com/aheber/tree-sitter-sfapex).
 
 > [!NOTE]
-> We're looking for contributors to help create a VSCode plugin! Feel free to join the [discussion](https://github.com/xixiaofinland/afmt/issues/83)!
+> A VS Code extension is now available: [afmt Formatter](https://marketplace.visualstudio.com/items?itemName=jprichter.afmt-code-ext).
+> It formats the in-memory buffer via `afmt -`, and expects the `afmt` binary to be installed separately.
 
 <br>
 
@@ -99,7 +100,7 @@ powershell -ExecutionPolicy Bypass -File install-afmt.ps1
 
 ### 2. Cargo Install
 
-`afmt` is published in creates.io [here](https://crates.io/crates/sf-afmt).
+`afmt` is published on crates.io [here](https://crates.io/crates/sf-afmt).
 Run cmd below if you have the `Cargo` tool.
 
 ```bash
@@ -191,7 +192,7 @@ mode, or partial write failure.
 
 `-c` parameter can read configuration settings from a toml file.
 
-Example: `afmt -c .afmt.toml`
+Example: `afmt -c .afmt.toml ./file.cls`
 
 In an explicitly supplied `.afmt.toml` config file, formatter settings, optional
 style controls, and optional file-selection settings are supported. A config
@@ -202,7 +203,7 @@ file is not loaded implicitly.
 max_width = 80
 
 # Indentation size in spaces
-indent_size = 4
+indent_size = 2
 
 # Optional style controls (defaults preserve afmt's existing output)
 # brace_style = "k_and_r"            # or "allman"
@@ -252,8 +253,9 @@ and contributor validation workflow, see
 ## ❓ FAQ
 
 - "TLTR, what features afmt has?" Run `afmt -h`.
-- "How do I set up afmt in VSCode?"
-[Setup in VSCode](./md/VSCode_Setup.md)
+- "How do I set up afmt in VS Code?"
+Install the [afmt Formatter extension](https://marketplace.visualstudio.com/items?itemName=jprichter.afmt-code-ext),
+or wire `afmt` up manually as a task: [Setup in VSCode](./md/VSCode_Setup.md)
 
 - "Can afmt formats exactly the same as Prettier Apex?"
 No.

--- a/docs/project-wide-formatting.md
+++ b/docs/project-wide-formatting.md
@@ -29,7 +29,7 @@ remain valid:
 
 ```toml
 max_width = 80
-indent_size = 4
+indent_size = 2
 
 [files]
 include = ["**/*.cls", "**/*.trigger", "**/*.apex", "**/*.apexc"]

--- a/md/VSCode_Setup.md
+++ b/md/VSCode_Setup.md
@@ -1,7 +1,9 @@
 # Config afmt in VSCode
 
-At the moment there is no dedicated plugin in VSCode for `afmt`, but we can
-usage the built-in `tasks` feature to invoke `afmt` from VSCode.
+The recommended setup is the [afmt Formatter extension](https://marketplace.visualstudio.com/items?itemName=jprichter.afmt-code-ext),
+which registers `afmt` as the native formatter for Apex files. If you would
+rather not install an extension, you can use VSCode's built-in `tasks` feature
+to invoke `afmt` from VSCode, as described below.
 
 VSCode supports running tasks via `tasks.json`, which allows running shell commands on files.
 


### PR DESCRIPTION
A VS Code extension for `afmt` now exists, so this replaces the note asking for contributors to build one with a link to it, and makes it the recommended setup in `md/VSCode_Setup.md` ahead of the manual `tasks.json` recipe.

It also fixes three inaccuracies found by checking the docs against the code:

- `indent_size` examples showed `4`; the default is `2` (`default_indent_size`, `src/source_formatter.rs`).
- `afmt -c .afmt.toml` is not runnable — `PATH` is required, so it exits `2`.
- "creates.io" → "crates.io".

Docs only.
