### PR TITLE
feat(afmt): locate parse errors by file, line, and column

### DIFF
--- a/docs/project-wide-formatting.md
+++ b/docs/project-wide-formatting.md
@@ -81,6 +81,35 @@ Exit status `0` means the requested operation completed successfully. Exit
 status `1` indicates an application error, a changed file in check mode, or a
 partial write failure.
 
+### Parse error locations
+
+A parse failure leads with the offending node's one-based line and column so an
+editor can jump to it, then reports the node kind, byte range, and snippet:
+
+```
+Error: force-app/main/default/classes/Broken.cls:3:19: parse error in node kind: ERROR, at byte range: 57-58, snippet: =
+Parent node kind: local_variable_declaration, at force-app/main/default/classes/Broken.cls:3:9, byte range: 47-60, snippet: Integer x = ;
+Parser encounters an error node in the tree.
+```
+
+The prefix follows the same origin rule as the unhonored-directive warning: the
+path afmt was given, `<stdin>` when the source arrived on stdin, and a bare
+`line:column` for a library caller that used
+`Formatter::try_format_source`. Because the diagnostic locates itself,
+`FormatFileError`'s `Display` omits its own path prefix when the message
+already opens with that path, so the path appears once per line.
+
+An editor integration that pipes a buffer through `afmt -` gets `<stdin>` as
+the origin — afmt is not told which file the buffer came from — so the client
+maps the reported line and column back onto the document it sent.
+
+`stdin_parse_errors_locate_the_error_by_line_and_column` and
+`file_parse_errors_carry_one_path_line_and_column` in `tests/cli.rs` pin this
+contract end to end, and `parse_failures_lead_with_the_error_node_location`,
+`parse_failures_locate_stdin_when_no_path_exists`, and
+`parse_failures_report_bare_line_and_column_without_an_origin` in
+`src/source_formatter.rs` pin the three origin forms.
+
 ### Changes to stdout from earlier releases
 
 Two stdout behaviors changed so that stdout carries the formatted document and

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -41,7 +41,14 @@ pub struct FormatFileError {
 
 impl std::fmt::Display for FormatFileError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "{}: {}", self.path.display(), self.message)
+        // Diagnostics that already lead with their own `path:line:column`
+        // locate themselves; prefixing the path again would repeat it.
+        let path = self.path.display().to_string();
+        if self.message.starts_with(&format!("{path}:")) {
+            return write!(formatter, "{}", self.message);
+        }
+
+        write!(formatter, "{}: {}", path, self.message)
     }
 }
 

--- a/src/source_formatter.rs
+++ b/src/source_formatter.rs
@@ -3,7 +3,9 @@ use crate::doc::{pretty_print, BraceStyle, IndentStyle, JavadocStarColumn, Prett
 use crate::doc_builder::DocBuilder;
 use crate::formatting_session::FormattingSession;
 use crate::message_helper::{red, yellow};
-use crate::utility::{assert_no_missing_comments, enrich, truncate_snippet};
+use crate::utility::{
+    assert_no_missing_comments, enrich, format_source_location, truncate_snippet,
+};
 use serde::Deserialize;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use tree_sitter::{Node, Parser, Tree};
@@ -119,7 +121,7 @@ fn try_format_source_unchecked(
         .validate()
         .map_err(|error| format!("Invalid formatter configuration: {error}"))?;
 
-    let ast_tree = try_parse(source_code)?;
+    let ast_tree = try_parse(source_code, origin)?;
     let _session = FormattingSession::new(source_code, &ast_tree, origin);
 
     // traverse the tree to build enriched data
@@ -148,10 +150,10 @@ fn try_format_source_unchecked(
 }
 
 pub(crate) fn parse(source_code: &str) -> Tree {
-    try_parse(source_code).unwrap_or_else(|message| panic!("{}", message))
+    try_parse(source_code, None).unwrap_or_else(|message| panic!("{}", message))
 }
 
-fn try_parse(source_code: &str) -> Result<Tree, String> {
+fn try_parse(source_code: &str, origin: Option<&str>) -> Result<Tree, String> {
     let mut parser = Parser::new();
     let language_fn = tree_sitter_sfapex::apex::LANGUAGE;
     parser
@@ -165,8 +167,12 @@ fn try_parse(source_code: &str) -> Result<Tree, String> {
         if let Some(error_node) = find_last_error_node(root_node) {
             let error_snippet =
                 truncate_snippet(&source_code[error_node.start_byte()..error_node.end_byte()]);
+            // Lead with the location so the first token is the jumpable
+            // `path:line:column` an editor can act on, the same shape the
+            // unhonored-directive warning uses.
             let mut diagnostic = format!(
-                "Error in node kind: {}, at byte range: {}-{}, snippet: {}",
+                "{}: parse error in node kind: {}, at byte range: {}-{}, snippet: {}",
+                node_location(&error_node, origin),
                 yellow(error_node.kind()),
                 error_node.start_byte(),
                 error_node.end_byte(),
@@ -175,8 +181,9 @@ fn try_parse(source_code: &str) -> Result<Tree, String> {
             if let Some(p) = error_node.parent() {
                 let parent_snippet = truncate_snippet(&source_code[p.start_byte()..p.end_byte()]);
                 diagnostic.push_str(&format!(
-                    "\nParent node kind: {}, at byte range: {}-{}, snippet: {}",
+                    "\nParent node kind: {}, at {}, byte range: {}-{}, snippet: {}",
                     yellow(p.kind()),
+                    node_location(&p, origin),
                     p.start_byte(),
                     p.end_byte(),
                     parent_snippet,
@@ -191,6 +198,14 @@ fn try_parse(source_code: &str) -> Result<Tree, String> {
     }
 
     Ok(ast_tree)
+}
+
+/// Renders a node's one-based start position, prefixed with the source origin
+/// when the caller named one. Parsing runs before the formatting session sets
+/// the thread-local origin, so it is threaded in explicitly here.
+fn node_location(node: &Node<'_>, origin: Option<&str>) -> String {
+    let start = node.start_position();
+    format_source_location(origin, start.row + 1, start.column + 1)
 }
 
 fn find_last_error_node<'tree>(node: &Node<'tree>) -> Option<Node<'tree>> {
@@ -223,7 +238,7 @@ fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{try_format_source, Config};
+    use super::{try_format_source, try_format_source_with_origin, Config};
 
     const VALID_SOURCE: &str = "class T { void m() {} }\n";
 
@@ -242,6 +257,53 @@ mod tests {
 
         assert!(error.contains("Parser encounters an error node"));
         assert!(!error.contains(".cls:"));
+    }
+
+    #[test]
+    fn parse_failures_lead_with_the_error_node_location() {
+        let error = try_format_source_with_origin(
+            "class Broken {\n    void run() {\n        Integer x = ;\n    }\n}\n",
+            Config::default(),
+            Some("Broken.cls"),
+        )
+        .expect_err("invalid source should fail");
+
+        // The offending token sits on line 3; the diagnostic must open with a
+        // jumpable location rather than a byte offset.
+        assert!(
+            error.starts_with("Broken.cls:3:"),
+            "diagnostic should lead with its location: {error}"
+        );
+        assert!(error.contains("byte range"));
+    }
+
+    #[test]
+    fn parse_failures_locate_stdin_when_no_path_exists() {
+        let error = try_format_source_with_origin(
+            "class Broken {\n    void run() {\n        Integer x = ;\n    }\n}\n",
+            Config::default(),
+            Some("<stdin>"),
+        )
+        .expect_err("invalid source should fail");
+
+        assert!(
+            error.starts_with("<stdin>:3:"),
+            "stdin diagnostic should carry the stdin origin: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_failures_report_bare_line_and_column_without_an_origin() {
+        let error = try_format_source(
+            "class Broken {\n    void run() {\n        Integer x = ;\n    }\n}\n",
+            Config::default(),
+        )
+        .expect_err("invalid source should fail");
+
+        assert!(
+            error.starts_with("3:"),
+            "library diagnostic should still locate the error: {error}"
+        );
     }
 
     #[test]

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -72,10 +72,16 @@ pub fn clear_thread_source_origin() {
 /// Renders `line:column`, prefixed with the source origin when one is known,
 /// matching the `Prefix: path: message` shape the CLI uses elsewhere.
 pub fn source_location(line: usize, column: usize) -> String {
-    THREAD_SOURCE_ORIGIN.with(|o| match o.borrow().as_deref() {
+    THREAD_SOURCE_ORIGIN.with(|o| format_source_location(o.borrow().as_deref(), line, column))
+}
+
+/// Same rendering as [`source_location`] for callers that hold the origin
+/// directly instead of reading the thread-local one.
+pub fn format_source_location(origin: Option<&str>, line: usize, column: usize) -> String {
+    match origin {
         Some(origin) => format!("{origin}:{line}:{column}"),
         None => format!("{line}:{column}"),
-    })
+    }
 }
 
 thread_local! {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -306,6 +306,52 @@ fn check_lists_all_changed_paths_and_accepts_a_fully_formatted_file() {
 }
 
 #[test]
+fn stdin_parse_errors_locate_the_error_by_line_and_column() {
+    let directory = temporary_directory();
+    let source = "public class Broken {\n    void run() {\n        Integer x = ;\n    }\n}\n";
+
+    let output = run_cli_with_stdin(&directory, &["-"], source);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    // The extension pipes a buffer, so `<stdin>` stands in for the path while
+    // the line and column still point at the offending token.
+    assert!(
+        stderr.contains("<stdin>:3:"),
+        "stdin parse error should be located: {stderr}"
+    );
+    assert!(stderr.contains("Parser encounters an error node"));
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
+fn file_parse_errors_carry_one_path_line_and_column() {
+    let directory = temporary_directory();
+    let invalid = directory.join("Broken.cls");
+    fs::write(
+        &invalid,
+        "public class Broken {\n    void run() {\n        Integer x = ;\n    }\n}\n",
+    )
+    .expect("invalid source should be written");
+
+    let output = run_cli(&directory, &[invalid.to_str().unwrap()]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    // The location is self-contained, so the `Error:` wrapper must not repeat
+    // the path it already carries.
+    let expected_opening = format!("Error: {}:3:", invalid.display());
+    let first_line = stderr.lines().next().expect("stderr should have a line");
+    assert!(
+        first_line.starts_with(&expected_opening),
+        "file parse error should open with a single located path: {first_line}"
+    );
+
+    fs::remove_dir_all(directory).expect("temporary directory should be removed");
+}
+
+#[test]
 fn check_parse_error_and_no_match_are_nonzero_without_writes() {
     let directory = temporary_directory();
     let invalid = directory.join("a-invalid.cls");


### PR DESCRIPTION
## Problem

Parse failures reported only byte offsets:

```
Error: Error in node kind: ERROR, at byte range: 3133-3149, snippet: ;
```

An editor integration piping a buffer through `afmt -` has nothing to jump to. This surfaced from the VS Code extension, which formats the in-memory buffer via stdin.

The cause is ordering: `try_parse` runs *before* `FormattingSession` sets the thread-local source origin, so the origin plumbing added in #`30bf9d3` for unhonored ignore directives could never reach the parse path.

## Change

Thread the origin into `try_parse` explicitly — parsing genuinely precedes the session, so reordering session setup would be the more fragile fix — and lead the diagnostic with `origin:line:column`:

```
Error: Broken.cls:3:19: parse error in node kind: ERROR, at byte range: 57-58, snippet: =
Parent node kind: local_variable_declaration, at Broken.cls:3:9, byte range: 47-60, snippet: Integer x = ;
```

Node kind, byte range, and snippet are retained. The origin rule matches the existing ignore-directive warning: the given path, `<stdin>` for stdin, bare `line:column` for a library caller.

`FormatFileError`'s `Display` now omits its own path prefix when the message already opens with that path; without it, file mode printed the path twice.

## Notes for review

- The conditional `Display` keys off message content. Alternatives: keep the duplication, or restructure so the message is never path-prefixed.
- **The message string changed** from `Error in node kind:` to `<location>: parse error in node kind:`. Pre-1.1.0 is the moment to catch anything grepping it.
- Five tests: three origin forms in `src/source_formatter.rs`, two end-to-end in `tests/cli.rs`. 107 pass, clippy clean.
