### PR TITLE
fix javadoc phantom star line

### DIFF
--- a/docs/comment-placement-and-idempotency.md
+++ b/docs/comment-placement-and-idempotency.md
@@ -30,6 +30,14 @@ following Apex node.
 These placements are attachment behavior, not alternate brace or indentation
 styles.
 
+## JavaDoc closing lines
+
+JavaDoc blocks (`/** ... */`) normalize a closing line that contains only stars
+before the terminator as an empty close. For example, `**/` and `***/` emit the
+same normal closing line as `*/`, using the configured star-column style, rather
+than creating a phantom content line such as `* *`. Text before the terminator
+is still treated as closing-line content and is emitted before a separate close.
+
 ## Ignored nodes
 
 A comment is a directive when its delimiters are stripped and its first
@@ -105,6 +113,10 @@ one matches its `.cls` and is unchanged by a second pass. The `ignore` scenario
 (also part of `all`), `ignored_inner_punctuation_is_idempotent`, and
 `idempotency_ignore_directive_stable_output` exercise the rest of that
 coverage.
+
+The JavaDoc fixture under `tests/comments/` covers star-only closing lines such
+as `**/`; `idempotency_comments` verifies that their normalized output is a
+fixed point.
 
 Three tests hold the stderr contract:
 `honored_ignore_directive_does_not_warn` asserts an applied marker stays

--- a/src/context.rs
+++ b/src/context.rs
@@ -223,7 +223,7 @@ impl<'a> DocBuild<'a> for Comment {
                         } else if i == lines.len() - 1 {
                             if let Some(before_end) = trimmed.strip_suffix("*/") {
                                 let content = before_end.trim();
-                                if content.is_empty() {
+                                if content.chars().all(|c| c == '*') {
                                     result.push(b.txt(format!("{star}/")));
                                 } else {
                                     result.push(b.txt(format!("{star} {content}"))); // First line: Preserve content

--- a/tests/comments/java_doc.cls
+++ b/tests/comments/java_doc.cls
@@ -41,5 +41,12 @@
  * @author   Someone
  */
 
+/**
+ * @Description Find Payment Profile.
+ */
+
+/**
+ */
+
 class A {
 }

--- a/tests/comments/java_doc.in
+++ b/tests/comments/java_doc.in
@@ -38,5 +38,12 @@ This is a JavaDoc
  * @author   Someone
  */
 
+/**
+ * @Description Find Payment Profile.
+**/
+
+/**
+**/
+
  Class A {
  }


### PR DESCRIPTION
## What changed

Normalize JavaDoc closing lines containing only extra stars (for example, **/) as ordinary closes, preventing phantom `* *` content. Add fixture coverage for content-adjacent and blank-line `**/` forms, plus focused documentation.

Why: older ApexDoc commonly uses `**/`, and the previous formatter emitted a stable but incorrect extra line.

Out of scope: other JavaDoc reformatting behavior and non-JavaDoc block comments.

Validation: focused comments tests, 102-test locked all-features suite, fmt check, and clippy with -D warnings.
