### PR TITLE
multiline string literals support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ focused project documentation below.
   [docs/comment-placement-and-idempotency.md](docs/comment-placement-and-idempotency.md)
 - Name-path chain formatting:
   [docs/name-path-chain-formatting.md](docs/name-path-chain-formatting.md)
+- Apex multiline string literal support:
+  [docs/multiline-string-literals.md](docs/multiline-string-literals.md)
 - User-facing bulk formatting, configuration, discovery, and CLI semantics:
   [docs/project-wide-formatting.md](docs/project-wide-formatting.md)
 - Test, battle-corpus, and local benchmark workflow:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +316,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,13 +432,14 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]
@@ -431,9 +452,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-sfapex"
-version = "2.4.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b97637acb3bcfc2518162ecf9b02a18b28a502cd7631bec5c2a26f4e5ea024b"
+checksum = "e902b5d7951d1477ff43ad5ec8b2e6adae029cce593a770c64e10362ee7dec7b"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -499,3 +520,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ serde = { version = "1.0.210", features = ["derive"] }
 clap = "4.5.16"
 toml = "0.8.19"
 typed-arena = "2.0.2"
-tree-sitter = "0.24.3"
-tree-sitter-sfapex = "2.4.0"
+tree-sitter = "0.26.9"
+tree-sitter-sfapex = "3.0.1"
 rayon = "1.10.0"
 globset = { version = "0.4.15", default-features = false }
 walkdir = "2.5.0"

--- a/docs/multiline-string-literals.md
+++ b/docs/multiline-string-literals.md
@@ -1,0 +1,42 @@
+# Multiline string literals
+
+`afmt` supports the Apex Summer '26 triple-quoted multiline string literal
+syntax (`'''...'''`). The parser dependency is `tree-sitter-sfapex 3.0.1`,
+which provides the `multi_line_string_literal` node and protects content such
+as `//` URLs from being parsed as comments.
+
+## Formatting behavior
+
+Multiline string nodes are handled through the existing general-expression and
+literal paths. Their source value is emitted as a single text document, so the
+triple-quote delimiters, internal line breaks, indentation, `${...}` text, and
+other contents are preserved. The formatter does not interpret interpolation
+inside the literal.
+
+The text width used for surrounding layout is the number of bytes before the
+first newline, rather than the total byte length of the multiline value. This
+prevents the literal's later lines from causing unrelated wrapping decisions on
+the line where the literal begins. The literal's own interior layout is not
+re-indented by the formatter.
+
+Multiline literals are supported in the grammar's general expression
+productions. SOQL-specific literal and geolocation paths continue to use the
+grammar's `string_literal` node because those productions do not accept
+`multi_line_string_literal`.
+
+## Regression coverage
+
+`tests/static/MultilineString.in` and `.cls` cover a multiline assignment, a
+method-call argument, interpolation-like text, and an `http://` URL inside the
+literal. The static fixture scenario also formats the expected output again to
+verify idempotency.
+
+Run the focused static and idempotency checks with:
+
+```bash
+cargo test --locked --test test statics
+cargo test --locked --test test idempotency_static
+```
+
+When changing this behavior, update the fixture pair and run the full locked
+checks described in [validation-and-benchmarks.md](validation-and-benchmarks.md).

--- a/docs/name-path-chain-formatting.md
+++ b/docs/name-path-chain-formatting.md
@@ -17,3 +17,9 @@ This is a canonical reflow rule: existing whitespace before a name-path dot is
 repaired rather than preserved. The battle-test script includes a syntactic
 check for any remaining line-start dot whose preceding nonblank line is a pure
 dotted-identifier path.
+
+When a chained expression follows a multiline string literal, the literal's
+interior lines are preserved and width accounting resumes at the closing
+delimiter's column. That prevents an earlier assignment from breaking solely
+because the literal contains newlines; the trailing chain still wraps when its
+own final line exceeds the configured width.

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -205,7 +205,9 @@ impl<'a> PrettyPrinter<'a> {
                         // do nothing to avoid "double spacing" in comment node handling
                     } else {
                         result.push_str(text);
-                        self.col += width;
+                        self.col = text
+                            .rsplit_once('\n')
+                            .map_or(self.col + width, |(_, last_line)| last_line.len() as u32);
                     }
                 }
                 Doc::Verbatim(text) => {
@@ -328,9 +330,13 @@ impl<'a> PrettyPrinter<'a> {
                         return true;
                     }
                 }
-                Doc::Text(_, text_width) => {
+                Doc::Text(text, text_width) => {
                     if *text_width <= remaining_width {
-                        remaining_width -= text_width;
+                        remaining_width = text
+                            .rsplit_once('\n')
+                            .map_or(remaining_width - text_width, |(_, last_line)| {
+                                self.max_width.saturating_sub(last_line.len() as u32)
+                            });
                     } else {
                         return false;
                     }

--- a/src/doc_builder.rs
+++ b/src/doc_builder.rs
@@ -191,7 +191,7 @@ impl<'a> DocBuilder<'a> {
 
     pub fn txt(&'a self, text: impl ToString) -> DocRef<'a> {
         let s = text.to_string();
-        let width = s.len() as u32;
+        let width = s.find('\n').unwrap_or(s.len()) as u32;
         self.arena.alloc(Doc::Text(s, width))
     }
 

--- a/src/enum_def.rs
+++ b/src/enum_def.rs
@@ -256,6 +256,7 @@ impl Expression {
             | "array_access"
             | "field_access"
             | "string_literal"
+            | "multi_line_string_literal"
             | "version_expression"
             | "java_field_access"
             | "this"
@@ -350,7 +351,8 @@ impl PrimaryExpression {
             | "decimal_floating_point_literal"
             | "boolean"
             | "null_literal"
-            | "string_literal" => Self::Literal(Literal_::new(n)),
+            | "string_literal"
+            | "multi_line_string_literal" => Self::Literal(Literal_::new(n)),
             "identifier" => Self::Identifier(ValueNode::new(n)),
             "class_literal" => Self::Class(ClassLiteral::new(n)),
             "method_invocation" => Self::Method(MethodInvocation::new(n)),
@@ -459,7 +461,7 @@ impl Literal_ {
             "boolean" => Self::Bool(ValueNodeLowerCase::new(node)),
             "null_literal" => Self::Null(ValueNodeLowerCase::new(node)),
             "int" => Self::Int(ValueNode::new(node)),
-            "string_literal" => Self::Str(ValueNode::new(node)),
+            "string_literal" | "multi_line_string_literal" => Self::Str(ValueNode::new(node)),
             "decimal_floating_point_literal" => Self::Decimal(ValueNodeLowerCase::new(node)),
             _ => panic_unknown_node(node, "Literal_"),
         }

--- a/src/source_formatter.rs
+++ b/src/source_formatter.rs
@@ -201,7 +201,7 @@ fn find_last_error_node<'tree>(node: &Node<'tree>) -> Option<Node<'tree>> {
     let mut last_error_node = Some(*node);
 
     for i in 0..node.child_count() {
-        if let Some(child) = node.child(i) {
+        if let Some(child) = node.child(i as u32) {
             if child.has_error() {
                 last_error_node = find_last_error_node(&child);
             }

--- a/tests/static/MultilineString.cls
+++ b/tests/static/MultilineString.cls
@@ -1,0 +1,20 @@
+public class MultilineString {
+  public static void run() {
+    String accountName = 'Acme';
+    String date = '2026-08-25';
+    String multiLineString = '''
+{
+"Account": "${accountName}",
+"Last Updated": "${date}",
+"Endpoint": "http://example.com/api"
+}
+''';
+    consume('''first line
+second line
+''');
+    String interpolation = '''${accountName}''';
+  }
+  private static void consume(String value) {
+    System.debug(value);
+  }
+}

--- a/tests/static/MultilineString.cls
+++ b/tests/static/MultilineString.cls
@@ -9,10 +9,13 @@ public class MultilineString {
 "Endpoint": "http://example.com/api"
 }
 ''';
-    consume('''first line
+    consume('''
+first line
 second line
 ''');
-    String interpolation = '''${accountName}''';
+    String interpolation = '''
+${accountName}
+''';
   }
   private static void consume(String value) {
     System.debug(value);

--- a/tests/static/MultilineString.in
+++ b/tests/static/MultilineString.in
@@ -1,0 +1,18 @@
+public class MultilineString{
+public static void run(){
+String accountName='Acme';
+String date='2026-08-25';
+String multiLineString='''
+{
+"Account": "${accountName}",
+"Last Updated": "${date}",
+"Endpoint": "http://example.com/api"
+}
+''';
+consume('''first line
+second line
+''');
+String interpolation='''${accountName}''';
+}
+private static void consume(String value){System.debug(value);}
+}

--- a/tests/static/MultilineString.in
+++ b/tests/static/MultilineString.in
@@ -9,10 +9,13 @@ String multiLineString='''
 "Endpoint": "http://example.com/api"
 }
 ''';
-consume('''first line
+consume('''
+first line
 second line
 ''');
-String interpolation='''${accountName}''';
+String interpolation='''
+${accountName}
+''';
 }
 private static void consume(String value){System.debug(value);}
 }

--- a/tests/static/MultilineStringChain.cls
+++ b/tests/static/MultilineStringChain.cls
@@ -1,0 +1,7 @@
+public class MultilineStringChain {
+  public static void run() {
+    String s = '''
+x
+'''.trim().toLowerCase().replace('a', 'b').substring(0, 10).trim();
+  }
+}

--- a/tests/static/MultilineStringChain.in
+++ b/tests/static/MultilineStringChain.in
@@ -1,0 +1,7 @@
+public class MultilineStringChain{
+public static void run(){
+String s='''
+x
+'''.trim().toLowerCase().replace('a', 'b').substring(0, 10).trim();
+}
+}

--- a/tests/static/MultilineStringNewline.cls
+++ b/tests/static/MultilineStringNewline.cls
@@ -1,0 +1,9 @@
+public class MultilineStringNewline {
+  public static void run() {
+    String body = '''
+first line
+second line
+''';
+    System.debug(body);
+  }
+}

--- a/tests/static/MultilineStringNewline.in
+++ b/tests/static/MultilineStringNewline.in
@@ -1,0 +1,9 @@
+public class MultilineStringNewline{
+public static void run(){
+String body='''
+first line
+second line
+''';
+System.debug(body);
+}
+}

--- a/tests/static/MultilineStringTrailingCode.cls
+++ b/tests/static/MultilineStringTrailingCode.cls
@@ -1,0 +1,7 @@
+public class MultilineStringTrailingCode {
+  public static void run() {
+    String s = '''
+x
+'''.trim();
+  }
+}

--- a/tests/static/MultilineStringTrailingCode.in
+++ b/tests/static/MultilineStringTrailingCode.in
@@ -1,0 +1,7 @@
+public class MultilineStringTrailingCode{
+public static void run(){
+String s='''
+x
+'''.trim();
+}
+}


### PR DESCRIPTION
## Summary

Adds Apex Summer 26 triple-quoted multiline string support by upgrading tree-sitter to 0.26.9 and tree-sitter-sfapex to 3.0.1, adapting the Node::child API, preserving multiline literal contents, correcting width accounting, and adding fixture/idempotency coverage including an http:// URL and the compiler's newline-after-quote rule.

Validation: cargo test --locked --all-features (102 passed), focused statics and idempotency tests, cargo fmt --all -- --check, cargo clippy --locked --all-targets --all-features -- -D warnings, and git diff --check. Fixture literals were confirmed to compile on a Summer 26 scratch org.

## Scope

Upstream grammar work and local //-in-string workarounds are out of scope because tree-sitter-sfapex 3.0.1 already contains the released fix. SOQL/geolocation literal paths remain unchanged because Salesforce itself rejects triple-quoted literals in those positions (verified on-org); they still reach a query through bind variables. Unrelated grammar changes are also excluded.
