### PR TITLE
fix(formatter): honor max_width = 0 as unlimited line width

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,9 @@ controls the logical indentation width; with tabs, it is the number of columns
 represented by each indentation level. Line wrapping uses that logical width
 when applying `max_width`.
 
+`max_width = 0` disables line-width wrapping entirely: afmt never breaks a
+line to fit a width, regardless of how long it gets.
+
 `javadoc_star_column` controls only the leading star on continuation lines in
 Javadoc (`/** ... */`) comments:
 

--- a/src/source_formatter.rs
+++ b/src/source_formatter.rs
@@ -79,8 +79,14 @@ impl Config {
         Ok(())
     }
 
+    /// Effective max width for line wrapping. `max_width = 0` means unlimited —
+    /// afmt never wraps a line to fit a width.
     pub fn max_width(&self) -> u32 {
-        self.max_width
+        if self.max_width == 0 {
+            u32::MAX
+        } else {
+            self.max_width
+        }
     }
 
     pub fn indent_size(&self) -> u32 {
@@ -139,7 +145,7 @@ fn try_format_source_unchecked(
     let b = DocBuilder::new(c);
     let doc_ref = root.build(&b);
 
-    let result = pretty_print(doc_ref, config.max_width, c);
+    let result = pretty_print(doc_ref, config.max_width(), c);
 
     // debugging tool: use this to print named node value + comments in bucket
     // print_comment_map(&ast_tree);
@@ -331,5 +337,32 @@ mod tests {
             try_format_source(&first, Config::default()).expect("formatted source formats");
 
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn zero_max_width_disables_line_wrapping() {
+        let source = "class T {\n    void m() {\n        System.debug(firstArgument, secondArgument, thirdArgument, fifthArgument, sixthArgument);\n    }\n}\n";
+
+        let wrapped =
+            try_format_source(source, Config::default()).expect("source formats at default width");
+        assert!(
+            wrapped.contains("System.debug(\n"),
+            "default max_width should wrap the long call: {wrapped}"
+        );
+
+        let unwrapped = try_format_source(
+            source,
+            Config {
+                max_width: 0,
+                ..Config::default()
+            },
+        )
+        .expect("source formats at unlimited width");
+        assert!(
+            unwrapped.contains(
+                "System.debug(firstArgument, secondArgument, thirdArgument, fifthArgument, sixthArgument);"
+            ),
+            "max_width = 0 should keep the call on one line: {unwrapped}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Follow-up from #1 (comment https://github.com/maciej-findock/afmt/pull/1#issuecomment-5288503337) — one of the items @jprichter flagged for upstreaming from my fork: `max_width = 0` as "unlimited".
- `Config::max_width()` returned the raw configured value, and `try_format_source_unchecked` passed the raw `config.max_width` field straight to `pretty_print` instead of going through the accessor. So `max_width = 0` produced a formatter that tried to wrap after almost every token, rather than disabling wrapping.
- `max_width()` now maps `0` → `u32::MAX`, and the source formatter reads through that accessor. Documented the behavior in `docs/configuration.md`.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (added `zero_max_width_disables_line_wrapping`, confirming a long call wraps at the default width but stays on one line with `max_width = 0`)

Note: `formatter::tests::path_native_constructor_preserves_non_utf8_paths` fails locally on macOS regardless of this change (non-UTF8 path can't be created on this filesystem) — unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)